### PR TITLE
Update chord types

### DIFF
--- a/src/generator/ChordType.js
+++ b/src/generator/ChordType.js
@@ -1,4 +1,7 @@
 export const ChordType = {
   TRIAD: "triad",
-  SEVENTH: "seventh"
+  SEVENTH: "seventh",
+  CHROMATIC: "chromatic variation",
+  MIXTURE: "mode mixture",
+  APPLIED: "applied"
 }


### PR DESCRIPTION
Add these cases to the chord type specification. These aren't used anywhere yet. Further work would be to lump "triad" and "seventh" into "in-key."