### PR TITLE
Make ChordType names more verbose

### DIFF
--- a/src/generator/ChordType.js
+++ b/src/generator/ChordType.js
@@ -1,7 +1,7 @@
 export const ChordType = {
   TRIAD: "triad",
   SEVENTH: "seventh",
-  CHROMATIC: "chromatic variation",
-  MIXTURE: "mode mixture",
-  APPLIED: "applied"
+  CHROMATIC_VARIATION: "chromatic variation",
+  MODE_MIXTURE: "mode mixture",
+  APPLIED_CHORD: "applied"
 }


### PR DESCRIPTION
This PR makes the new `ChordType` case names more verbose.