### PR TITLE
Bring jest-styled-components into generator-v2

### DIFF
--- a/src/tests/Go.test.js
+++ b/src/tests/Go.test.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { render, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 import Go from '../components/views/buttons/Go'
+import 'jest-styled-components'
 
 
 test('calls "generator" on click', () => {

--- a/src/tests/Loading.test.js
+++ b/src/tests/Loading.test.js
@@ -2,6 +2,8 @@ import React from 'react'
 import { render } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 import Loading from '../components/views/layouts/Loading'
+import 'jest-styled-components'
+
 
 test('loads with correct text', () => {
   const { getByRole, asFragment } = render(

--- a/src/tests/__snapshots__/Go.test.js.snap
+++ b/src/tests/__snapshots__/Go.test.js.snap
@@ -2,8 +2,15 @@
 
 exports[`calls "generator" on click 1`] = `
 <DocumentFragment>
-  <button
-    class="sc-AykKC hCaSnZ btn btn-dark"
+  .c0 {
+  display: block;
+  cursor: pointer;
+  border: none;
+  padding: 0;
+}
+
+<button
+    class="c0 btn btn-dark"
     type="button"
   >
     <img


### PR DESCRIPTION
This PR brings `jest-styled-components` into the `generator-v2` branch. It serves to tickle Travis to see what happens.