### PR TITLE
Add tests for chord generation process up to concretizeRoot

### DIFF
--- a/src/generator/Accidental.js
+++ b/src/generator/Accidental.js
@@ -6,12 +6,8 @@ export const Accidental = {
   DOUBLESHARP: "𝄪",
   offset: function(accidental) {
     return Object.values(this).indexOf(accidental)
+  },
+  offsetFromNatural: function(accidental) {
+    return this.offset(accidental) - this.offset(this.NATURAL)
   }
-}
-
-/**
- * @returns Int The distance from the given `accidental` to `Accidental.Natural`
- */
-export function distanceFromNatural(accidental) {
-  return Accidental.offset(accidental) - Accidental.offset(Accidental.NATURAL)
 }

--- a/src/generator/Accidental.js
+++ b/src/generator/Accidental.js
@@ -3,5 +3,15 @@ export const Accidental = {
   FLAT: "♭",
   NATURAL: "♮",
   SHARP: "♯",
-  DOUBLESHARP: "𝄪"
+  DOUBLESHARP: "𝄪",
+  offset: function(accidental) {
+    return Object.values(this).indexOf(accidental)
+  }
+}
+
+/**
+ * @returns Int The distance from the given `accidental` to `Accidental.Natural`
+ */
+export function distanceFromNatural(accidental) {
+  return Accidental.offset(accidental) - Accidental.offset(Accidental.NATURAL)
 }

--- a/src/generator/Mode.js
+++ b/src/generator/Mode.js
@@ -125,6 +125,8 @@ export function noteIdentities(mode) {
         {"tensionMod7":7,"quality":-1,"incidental":0},
         {"tensionMod7":7,"quality":1,"incidental":1}
       ]
+      default:
+        throw "Unsupported Mode: " + JSON.stringify(mode)
     }
 }
 

--- a/src/generator/Mode.js
+++ b/src/generator/Mode.js
@@ -131,7 +131,6 @@ export function noteIdentities(mode) {
 }
 
 export function degree(mode, modeNote) {
-  console.log("degree incoming mode: " + JSON.stringify(mode) + " and mode note: " + JSON.stringify(modeNote))
   switch (mode) {
     case Mode.MAJOR:
       return Object.values(ModeSubset.MAJOR).indexOf(modeNote)+1

--- a/src/generator/RomanNumeral.js
+++ b/src/generator/RomanNumeral.js
@@ -16,12 +16,9 @@ export const RomanNumeral = {
 }
 
 export function degreeAndQualityToRomanNumeral(degree, isCapital) {
-  console.log("degree and quality to roman numeral incoming degree: " + degree + " is capital: " + isCapital)
   if (isCapital) {
-    console.log("result: " + Object.keys(RomanNumeral)[degree - 1])
     return Object.keys(RomanNumeral)[degree - 1]
   } else {
-    console.log("result: " + Object.keys(RomanNumeral)[degree - 1 + 7])
     return Object.keys(RomanNumeral)[degree - 1 + 7]
   }
 }

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -280,7 +280,7 @@ export function randomChord(options) {
   //    structure: ChordStructure,
   //    inversion: Int
   // }
-  const chordDescription = makeChordDescription(chordType, inversion, keySignature)
+  const chordDescription = makeChordDescription(chordStructure, inversion, keySignature)
 
   console.log("I have made a chordDescription: " + JSON.stringify(chordDescription))
 
@@ -305,10 +305,10 @@ export function randomChord(options) {
 // random chord!
 //
 // => (Note,Int)
-export function makeChordDescription(chordType, inversion, keySignature) {
-  // Choose one of the possible chord structures for the given chord type
-  // Consider making this a function that generates an abstract chord rather than chooses one of the representations currently in ChordStructure
-  const chordStructure = chooseChordStructure(chordType)
+export function makeChordDescription(chordStructure, inversion, keySignature) {
+  // // Choose one of the possible chord structures for the given chord type
+  // // Consider making this a function that generates an abstract chord rather than chooses one of the representations currently in ChordStructure
+  // const chordStructure = chooseChordStructure(chordType)
   // Choose random roman numeral context
   const romanNumeralContext = randomRomanNumeralContext(chordStructure)
   // Concretize the root by situating the roman numeral context's `modeNote` in the given 
@@ -364,7 +364,8 @@ export function partiallyConcretizeChord(chordDescription, keySignature) {
   const rootAccidental = chordDescription.root.accidental
   const rootSyllable = chordDescription.root.syllable
 
-  console.log("root: " + JSON.stringify(chordDescription.root))
+  console.log("partially concretize chord with root: " + JSON.stringify(chordDescription.root))
+  console.log("structure: ")
 
   // The notes of a chord to be returned
   let notes = []
@@ -778,6 +779,7 @@ function inversions(chordType) {
  * @return {type}                An object consisting of a mode, a mode note, scale degree, and roman numeral.
  */
 export function randomRomanNumeralContext(chordStructure) {
+
   // FIXME: Consider adding configurability of allowable range of "shapes" and complexity
   const mode = allowedModesByChordStructure[chordStructure].randomElement()
   switch (chordStructure) {

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -630,6 +630,7 @@ function chooseRootAccidental(syllable, structure, allowedAccidentals) {
  * @param  {type} keySignature A randomly chosen key signature represented as a shape
  * @param  {type} modeNote     The mode of the root note
  * @return {type}              An object consisting of the independent pitch, the accidental, and the letter name for the root note.
+ * @todo                       This algorithm works in quadratic time, but could quite possibly work in constant time.
  */
 export function concretizeRoot(keySignature, modeNote) {
 
@@ -654,8 +655,6 @@ export function concretizeRoot(keySignature, modeNote) {
       const rootSyllableIndex = Object.values(IndependentPitch).indexOf(rootSyllable)
       const rootIPIndex = (rootSyllableIndex + offset) % 12
       const rootIP = Object.values(IndependentPitch)[rootIPIndex]
-
-      console.log("About to return from concretizeRoot with letter: " + rootLetter)
 
       return {
         independentPitch: rootIP,

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -644,12 +644,8 @@ export function concretizeRoot(keySignature, modeNote) {
       const rootAccidental = shape.notes[i].accidental
       const rootSyllable = shape.notes[i].refIP
 
-      // FIXME: (James) Implement convenience getter over `Accidental`
-      const naturalOffset = Object.values(Accidental).indexOf(Accidental.NATURAL)
-      console.log("natural offset " + naturalOffset)
-      const accidentalIndex = Object.keys(Accidental).indexOf(rootAccidental)
-      const offset = (Object.values(Accidental).indexOf(rootAccidental))-(Object.values(Accidental).indexOf(Accidental.NATURAL))
-      console.log("syllable offset: " + offset)
+      // Get the offset from the root accidental from `NATURAL`
+      const offset = Accidental.offsetFromNatural(rootAccidental)
 
       // FIXME: (James) Implement convenience getter over `LetterName`
       const rootLetter = Object.values(LetterName)[Object.values(IndependentPitchSubset.BOTTOM).indexOf(rootSyllable)]

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -418,16 +418,14 @@ function chordComponentSyllable(translatedNoteIPIndex, chordDescription) {
 
 /**
  * @param rootIP            IndependentPitch  The IndependentPitch syllable of the root of a chord
- * @param translatedNoteIP  Int               The index of the translated note independent pitch
+ * @param translatedNoteIPIndex  Int               The index of the translated note independent pitch
  * @param keySignature      KeySignature      The KeySignature context of the chord
  */
 // find the equivalent IP based on the rootIp and tensionMod12 value in the class
-function chordComponentIndependentPitch(rootIP, translatedNoteIP, keySignature) {
+function chordComponentIndependentPitch(rootIP, translatedNoteIPIndex, keySignature) {
   const ips = Object.values(IndependentPitch)
   const rootIPIndex = ips.indexOf(rootIP)
-  const shape = Shapes[keySignature]
-  const noteOffsetInShape = shape[translatedNoteIP].tensionMod12 - 1
-  return ips[(rootIPIndex + noteOffsetInShape) % 12]
+  return ips[(rootIPIndex + translatedNoteIPIndex) % 12]
 }
 
 // TODO: (David) make sure this matches with the range set in randomChoice(clefs)

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -542,7 +542,7 @@ function chordTypesOption(chordTypes) {
 }
 
 // return Type of the chord we are constructing
-function chooseChordType(chordTypesOption) {
+export function chooseChordType(chordTypesOption) {
   switch (chordTypesOption) {
     case ChordTypesOption.TRIADS:
       return ChordType.TRIAD

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -272,19 +272,19 @@ export function randomChord(options) {
   // Choose a `KeySignature`
   const keySignature = chooseKeySignature()
 
+  const romanNumeralContext = randomRomanNumeralContext(chordStructure)
+
   // Construct non—octave-positioned description of a chord, in the form:
   // {
   //    root: { independentPitch, accidental, letter, syllable },
   //    structure: ChordStructure,
   //    inversion: Int
   // }
-  const chordDescription = makeChordDescription(chordStructure, inversion, keySignature)
+  const chordDescription = makeChordDescription(chordStructure, inversion, keySignature, romanNumeralContext)
 
   // Construct the non-octave positioned notes for chord described above
   // TODO: Come up with a better name
   const partiallyConcretizedChordNotes = partiallyConcretizeChord(chordDescription, keySignature)
-
-  console.log("I have partially concretized chord notes: " + JSON.stringify(partiallyConcretizedChordNotes))
 
   // TODO: (James) add `inversion` method on `Chord` type
   // const inverted = handleInversion(chordDescription, inversion)
@@ -301,12 +301,7 @@ export function randomChord(options) {
 // random chord!
 //
 // => (Note,Int)
-export function makeChordDescription(chordStructure, inversion, keySignature) {
-  // // Choose one of the possible chord structures for the given chord type
-  // // Consider making this a function that generates an abstract chord rather than chooses one of the representations currently in ChordStructure
-  // const chordStructure = chooseChordStructure(chordType)
-  // Choose random roman numeral context
-  const romanNumeralContext = randomRomanNumeralContext(chordStructure)
+export function makeChordDescription(chordStructure, inversion, keySignature, romanNumeralContext) {
   // Concretize the root by situating the roman numeral context's `modeNote` in the given 
   // `keySignature`.
   const concretizedRoot = concretizeRoot(keySignature, romanNumeralContext.modeNote)
@@ -807,11 +802,20 @@ function chooseRandomAccidental(allowedAccidentals) {
  *
  * @param  {type} chordStructure The chord structure to create context for.
  * @return {type}                An object consisting of a mode, a mode note, scale degree, and roman numeral.
+ * @todo                         Rename to `chooseRomanNumeralContext`
  */
 export function randomRomanNumeralContext(chordStructure) {
 
-  // FIXME: Consider adding configurability of allowable range of "shapes" and complexity
-  const mode = allowedModesByChordStructure[chordStructure].randomElement()
+  // FIXME: Codify "Major" and "minor" here!  
+  const modeLabel = chordStructure.possibleModeEnvironments.randomElement()
+  let mode
+  switch (modeLabel) {
+    case "Major":
+      mode = Mode.MAJOR
+    case "minor":
+      mode = Mode.MINOR
+  }
+
   switch (chordStructure) {
     case ChordStructure.MAJOR:
       switch (mode) {

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -527,43 +527,14 @@ function octaveTranspose(notes, octaves) {
   })
 }
 
-// This function takes converts a pair of Boolean values into a tri-state enum `ChordTypesOption` so that we invalidate the case where both triads and seventh chords are false.
 
-function chordTypesOption(chordTypes) {
-  console.log("chord types option from " + JSON.stringify(chordTypes))
-  if (chordTypes.triads && chordTypes.sevenths) {
-    return ChordTypesOption.BOTH
-  } else if (chordTypes.triads && !chordTypes.sevenths) {
-    return ChordTypesOption.TRIADS
-  } else if (!chordTypes.triads && chordTypes.sevenths) {
-    return ChordTypesOption.SEVENTHS
-  } else {
-    throw "Invalid chord types selection"
-  }
-}
-
-// return Type of the chord we are constructing
-export function chooseChordType(chordTypesOption) {
-  switch (chordTypesOption) {
-    case ChordTypesOption.TRIADS:
-      return ChordType.TRIAD
-    case ChordTypesOption.SEVENTHS:
-      return ChordType.SEVENTH
-    case ChordTypesOption.BOTH:
-      return [ChordType.TRIAD, ChordType.SEVENTH].randomElement()
-    default:
-      throw 'Impossible ChordTypesOption'
-  }
-}
 
 const RootOption = {
   ANY: "any",
   COMMON: "common"
 }
 
-function chooseRandomAccidental(allowedAccidentals) {
-  return allowedAccidentals.randomElement()
-}
+
 
 // Constrains accidental only for root pitch
 function constrainAccidental(syllable, structure, initialChoice) {
@@ -695,19 +666,6 @@ const allowedModesByChordStructure = {
   [ChordStructure.FULLY_DIMINISHED_SEVENTH]: [Mode.MAJOR, Mode.MINOR]
 }
 
-function chooseInitialOctave(clef) {
-  switch (clef) {
-    case Clef.BASS:
-      // range of 4 octaves starting from octave 1
-      return Math.floor(Math.random() * 4) + 1
-    case Clef.TREBLE:
-      // range of 4 octaves starting from octave 3
-      return Math.floor(Math.random() * 4) + 3
-    default:
-      throw new Error('invalid clef')
-  }
-}
-
 export function translateNoteIPIndex(componentIP, rootIP) {
   const untranslatedIndex = Object.values(IndependentPitch).indexOf(componentIP)
   // TODO: audit addition of 12 here
@@ -718,8 +676,6 @@ export function translateNoteIPIndex(componentIP, rootIP) {
 // TODO: Decouple inversion from amount of notes in chord
 // TODO: Move into partiallyConcretizeChordNotes
 function handleInversion(chord, inversion) {
-
-  console.log("handle inversion for chord: " + JSON.stringify(chord) + "by inversion " + JSON.stringify(inversion))
 
   // inverts the chord, reorders chord.notes, and adjusts the ordered answer for inversion
   if ((inversion === "63") || (inversion === "65")) {
@@ -765,6 +721,81 @@ function inversions(chordType) {
     case ChordType.SEVENTH:
       return ["","65","43","42"]
   }
+}
+
+/**
+ * @param ChordType chordType The type of chord affording inversions from which to select
+ * @return A random inversion from those afforded by the given `chordType`
+ */
+export function chooseInversion(chordType) {
+  // TODO: Implement inversions as an instance method over `ChordType`
+  return inversions(chordType).randomElement()
+}
+
+/**
+ * @return  A random key signature within the realm of reason (omitting c+f flat, e+b sharp)
+ * @todo    Add some configurability with an input of allowed key signatures, with some 
+ *          sensible default
+ */
+export function chooseKeySignature() {
+  return Object.keys(Shapes).slice(3, 12).randomElement()
+}
+
+/**
+ * @return A random `Clef`.
+ */
+export function chooseClef() {
+  return Clef.randomElement()
+}
+
+/**
+ * @return A random `ChordStructure` for the given `chordType`.
+ */
+export function chooseChordStructure(chordType) {
+  return chordStructures(chordType).randomElement()
+}
+
+function chordTypesOption(chordTypes) {
+  if (chordTypes.triads && chordTypes.sevenths) {
+    return ChordTypesOption.BOTH
+  } else if (chordTypes.triads && !chordTypes.sevenths) {
+    return ChordTypesOption.TRIADS
+  } else if (!chordTypes.triads && chordTypes.sevenths) {
+    return ChordTypesOption.SEVENTHS
+  } else {
+    throw "Invalid chord types selection"
+  }
+}
+
+// return Type of the chord we are constructing
+export function chooseChordType(chordTypesOption) {
+  switch (chordTypesOption) {
+    case ChordTypesOption.TRIADS:
+      return ChordType.TRIAD
+    case ChordTypesOption.SEVENTHS:
+      return ChordType.SEVENTH
+    case ChordTypesOption.BOTH:
+      return [ChordType.TRIAD, ChordType.SEVENTH].randomElement()
+    default:
+      throw 'Impossible ChordTypesOption'
+  }
+}
+
+function chooseInitialOctave(clef) {
+  switch (clef) {
+    case Clef.BASS:
+      // range of 4 octaves starting from octave 1
+      return Math.floor(Math.random() * 4) + 1
+    case Clef.TREBLE:
+      // range of 4 octaves starting from octave 3
+      return Math.floor(Math.random() * 4) + 3
+    default:
+      throw new Error('invalid clef')
+  }
+}
+
+function chooseRandomAccidental(allowedAccidentals) {
+  return allowedAccidentals.randomElement()
 }
 
 /**
@@ -949,36 +980,4 @@ export function randomRomanNumeralContext(chordStructure) {
     default:
       throw new Error("Invalid chord structure")
   }
-}
-
-/**
- * @param ChordType chordType The type of chord affording inversions from which to select
- * @return A random inversion from those afforded by the given `chordType`
- */
-export function chooseInversion(chordType) {
-  // TODO: Implement inversions as an instance method over `ChordType`
-  return inversions(chordType).randomElement()
-}
-
-/**
- * @return  A random key signature within the realm of reason (omitting c+f flat, e+b sharp)
- * @todo    Add some configurability with an input of allowed key signatures, with some 
- *          sensible default
- */
-export function chooseKeySignature() {
-  return Object.keys(Shapes).slice(3, 12).randomElement()
-}
-
-/**
- * @return A random `Clef`.
- */
-export function chooseClef() {
-  return Clef.randomElement()
-}
-
-/**
- * @return A random `ChordStructure` for the given `chordType`.
- */
-export function chooseChordStructure(chordType) {
-  return chordStructures(chordType).randomElement()
 }

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -351,7 +351,7 @@ export function partiallyConcretizeChord(chordDescription, keySignature) {
 
     // FIXME: (James) Make a helper function that tidies this up
     // find the accidental from the diff between IP and "natural" syllable (natural is accidentals[2])
-    const accidentalVal = (Object.values(IndependentPitch).indexOf(noteIP))-(Object.values(IndependentPitch).indexOf(syllable))
+    let accidentalVal = (Object.values(IndependentPitch).indexOf(noteIP))-(Object.values(IndependentPitch).indexOf(syllable))
 
     // FIXME: (James) Perhaps break this into a function of its own
     // FIXME: Add convenience getters to IndependentPitch to avoid the `Object.values` choreography

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -326,16 +326,17 @@ export function makeChordDescription(chordStructure, inversion, keySignature) {
  */
 export function partiallyConcretizeChord(chordDescription, keySignature) {
 
-  // const { rootIP, rootAccidental, rootLetter, rootSyllable } = chordDescription.root
   const rootIP = chordDescription.root.independentPitch
   const rootAccidental = chordDescription.root.accidental
   const rootSyllable = chordDescription.root.syllable
 
   // The notes of a chord to be returned
+  // TODO: Consider implementing this with `map`
   let notes = []
 
   // build the structure with correct spellings
   // FIXME: Assess schema (diving `structure.structure` is not elegant)
+  // TODO: Consider breaking out the body of this loop into its own function
   for(var i=0; i<chordDescription.structure.structure.length; i++){
 
     // Translate the template ip to a relative note in the class

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -364,14 +364,12 @@ export function partiallyConcretizeChord(chordDescription, keySignature) {
   const rootAccidental = chordDescription.root.accidental
   const rootSyllable = chordDescription.root.syllable
 
-  console.log("partially concretize chord with root: " + JSON.stringify(chordDescription.root))
-  console.log("structure: ")
-
   // The notes of a chord to be returned
   let notes = []
 
   // build the structure with correct spellings
-  for(var i=0; i<chordDescription.structure.length; i++){
+  // FIXME: Assess schema (diving `structure.structure` is not elegant)
+  for(var i=0; i<chordDescription.structure.structure.length; i++){
 
     // translate the template ip to a relative note in the class
     const translatedNoteIP = translateNoteIPIndex(chordDescription.structure[i], rootIP)

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -349,27 +349,6 @@ export function partiallyConcretizeChord(chordDescription, keySignature) {
     // find the equivalent IP based on the rootIp and tensionMod12 value in the class
     const noteIP = chordComponentIndependentPitch(rootIP, translatedNoteIP, keySignature)
 
-    // FIXME: (James) Make a helper function that tidies this up
-    // find the accidental from the diff between IP and "natural" syllable (natural is accidentals[2])
-    let accidentalVal = (Object.values(IndependentPitch).indexOf(noteIP))-(Object.values(IndependentPitch).indexOf(syllable))
-
-    // FIXME: (James) Perhaps break this into a function of its own
-    // FIXME: Add convenience getters to IndependentPitch to avoid the `Object.values` choreography
-    // adjusts for IPs on opposite ends of the array, like "D" from "R"
-    // but something about this feels hacky... is there a better way?
-    if (accidentalVal > Object.values(IndependentPitch).length/2) {
-      accidentalVal -= Object.values(IndependentPitch).length
-    }
-    if (-accidentalVal > Object.values(IndependentPitch).length/2) {
-      accidentalVal += Object.values(IndependentPitch).length
-    }
-
-    // FIXME: (James) Add a convenience getter to Accidental to avoid the `Object.values` choreography
-    const accidental = Object.values(Accidental)[(2 + accidentalVal)%5]
-
-    // Translate the syllable "position" to a letter
-    // FIXME: Add convenience getters to LetterName to avoid the `Object.values` choreography
-
     const syllableIndex = Object.values(IndependentPitchSubset.BOTTOM).indexOf(syllable)
     const noteLetter = Object.values(LetterName)[syllableIndex]
 
@@ -388,7 +367,7 @@ export function partiallyConcretizeChord(chordDescription, keySignature) {
     const octave = 4
 
     // Create the note with all of our nice new data
-    const note = { letter: noteLetter, accidental: accidental, octave: octave }
+    const note = { letter: noteLetter, accidental: accidental(noteIP, syllable), octave: octave }
 
     // Append our new note to the array to be returned
     notes.push(note)
@@ -432,6 +411,26 @@ function chordComponentIndependentPitch(rootIP, translatedNoteIPIndex, keySignat
   const ips = Object.values(IndependentPitch)
   const rootIPIndex = ips.indexOf(rootIP)
   return ips[(rootIPIndex + translatedNoteIPIndex) % 12]
+}
+
+function accidental(independentPitch, syllable) {
+  // FIXME: (James) Make a helper function that tidies this up
+  // find the accidental from the diff between IP and "natural" syllable (natural is accidentals[2])
+  let accidentalVal = (Object.values(IndependentPitch).indexOf(independentPitch))-(Object.values(IndependentPitch).indexOf(syllable))
+
+  // FIXME: (James) Perhaps break this into a function of its own
+  // FIXME: Add convenience getters to IndependentPitch to avoid the `Object.values` choreography
+  // adjusts for IPs on opposite ends of the array, like "D" from "R"
+  // but something about this feels hacky... is there a better way?
+  if (accidentalVal > Object.values(IndependentPitch).length/2) {
+    accidentalVal -= Object.values(IndependentPitch).length
+  }
+  if (-accidentalVal > Object.values(IndependentPitch).length/2) {
+    accidentalVal += Object.values(IndependentPitch).length
+  }
+  // FIXME: (James) Add a convenience getter to Accidental to avoid the `Object.values` choreography
+  const accidental = Object.values(Accidental)[(2 + accidentalVal)%5]
+  return accidental
 }
 
 /**

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -393,7 +393,7 @@ export function partiallyConcretizeChord(chordDescription, keySignature) {
 
 
 function chordComponentSyllable(translatedNoteIPIndex, chordDescription) {
-  // FIXME: Come up with a name that is neither `whiteNotes` or `.BOTTOM`
+  // FIXME: Come up with a name that is neither `whiteNotes` nor `.BOTTOM`
   const whiteNotes = Object.values(IndependentPitchSubset.BOTTOM)
   const rootSyllable = chordDescription.root.syllable
   const rootSyllableIndex = whiteNotes.indexOf(rootSyllable)

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -357,9 +357,14 @@ function componentIP(rootIP, translatedNoteIP, keySignature) {
  * @param chordDescription
  * @return An array of non-octave-positioned spelled pitches comprising a `chord`.
  */
-function partiallyConcretizeChord(chordDescription, keySignature) {
+export function partiallyConcretizeChord(chordDescription, keySignature) {
 
-  const { rootIP, rootAccidental, rootLetter, rootSyllable } = chordDescription.root
+  // const { rootIP, rootAccidental, rootLetter, rootSyllable } = chordDescription.root
+  const rootIP = chordDescription.root.independentPitch
+  const rootAccidental = chordDescription.root.accidental
+  const rootSyllable = chordDescription.root.syllable
+
+  console.log("root: " + JSON.stringify(chordDescription.root))
 
   // The notes of a chord to be returned
   let notes = []
@@ -627,6 +632,9 @@ function chooseRootAccidental(syllable, structure, allowedAccidentals) {
  * @return {type}              An object consisting of the independent pitch, the accidental, and the letter name for the root note.
  */
 export function concretizeRoot(keySignature, modeNote) {
+
+  console.log("concretize root in key signature " + keySignature + " with mode note: " + modeNote)
+
   // TODO: ask David-- how do we know accidental at the shapes level of abstraction?
   // TODO: Configure the Shapes object so we don't have iterate through an array of notes each time
   // TODO: Use this function to generate every note not just roots? If so, rename to something like concretizeNote.
@@ -637,15 +645,21 @@ export function concretizeRoot(keySignature, modeNote) {
       const rootSyllable = shape.notes[i].refIP
 
       // FIXME: (James) Implement convenience getter over `Accidental`
-      const offset = (Object.keys(Accidental).indexOf(rootAccidental))-(Object.keys(Accidental).indexOf(Accidental.NATURAL))
+      const naturalOffset = Object.values(Accidental).indexOf(Accidental.NATURAL)
+      console.log("natural offset " + naturalOffset)
+      const accidentalIndex = Object.keys(Accidental).indexOf(rootAccidental)
+      const offset = (Object.values(Accidental).indexOf(rootAccidental))-(Object.values(Accidental).indexOf(Accidental.NATURAL))
+      console.log("syllable offset: " + offset)
 
       // FIXME: (James) Implement convenience getter over `LetterName`
-      const rootLetter = Object.keys(LetterName)[Object.keys(IndependentPitchSubset.BOTTOM).indexOf(rootSyllable)]
+      const rootLetter = Object.values(LetterName)[Object.values(IndependentPitchSubset.BOTTOM).indexOf(rootSyllable)]
 
       // FIXME: (James) Implement convenience getter over `IndependentPitch`
       const rootSyllableIndex = Object.values(IndependentPitch).indexOf(rootSyllable)
       const rootIPIndex = (rootSyllableIndex + offset) % 12
       const rootIP = Object.values(IndependentPitch)[rootIPIndex]
+
+      console.log("About to return from concretizeRoot with letter: " + rootLetter)
 
       return {
         independentPitch: rootIP,

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -397,7 +397,19 @@ function chordComponentSyllable(translatedNoteIPIndex, chordDescription) {
   const whiteNotes = Object.values(IndependentPitchSubset.BOTTOM)
   const rootSyllable = chordDescription.root.syllable
   const rootSyllableIndex = whiteNotes.indexOf(rootSyllable)
-  const modeConstructor = chordDescription.structure.modeConstructor
+  let modeConstructor = chordDescription.structure.modeConstructor
+
+  // FIXME: This sanitizes the mode constructors for chords which are set as `MAJOR` or `DOMINANT`,
+  //        and changes them to `LYDIAN_DOMINANT`. Likewise, we change `MINOR` inputs to `DORIAN`.
+  //
+  //        Either, we need change the values of the chord structure schema, or we need to flesh out
+  //        our `noteIdentities(mode)`.
+  if (modeConstructor === Mode.MAJOR || modeConstructor === Mode.DOMINANT) {
+    modeConstructor = Mode.LYDIAN_DOMINANT
+  } else if (modeConstructor === Mode.MINOR) {
+    modeConstructor = Mode.DORIAN
+  }
+
   const modeNoteIdentities = noteIdentities(modeConstructor)
   const tensionMod7 = noteIdentities(modeConstructor)[translatedNoteIPIndex].tensionMod7
   const index = (rootSyllableIndex + tensionMod7 - 1) % 7

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -346,6 +346,7 @@ export function partiallyConcretizeChord(chordDescription, keySignature) {
     // find the equivalent IP based on the rootIp and tensionMod12 value in the class
     let noteIP = chordComponentIndependentPitch(rootIP, translatedNoteIP, keySignature)
 
+    // FIXME: (James) Make a helper function that tidies this up
     // find the accidental from the diff between IP and "natural" syllable (natural is accidentals[2])
     let accidentalVal = (Object.values(IndependentPitch).indexOf(noteIP))-(Object.values(IndependentPitch).indexOf(syllable))
 
@@ -365,7 +366,8 @@ export function partiallyConcretizeChord(chordDescription, keySignature) {
 
     // Translate the syllable "position" to a letter
     // FIXME: Add convenience getters to LetterName to avoid the `Object.values` choreography
-    let noteLetter = Object.values(LetterName)[Object.values(ModeSubset.BOTTOM).indexOf(syllable)]
+
+    let noteLetter = Object.values(LetterName)[Object.values(IndependentPitchSubset.BOTTOM).indexOf(syllable)]
 
     // FIXME: (James) This currently requires context not injected into this function.
     //        We should do this octave adjustment after the fact, once we are put in a clef'd universe.

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -260,8 +260,15 @@ export function randomChord(options) {
   // Shuffles the root note choices so they're not always in root position haha
   // shuffle(chord.questions[1].choices)
 
+  // Choose a `ChordType` from the constraints provided by the user
   const chordType = chooseChordType(chordTypesOption(options.chordTypes))
   console.log("I have chosen a chord type: " + JSON.stringify(chordType))
+
+  // Choose a `ChordStructure` belonging to the chosen `ChordType` family
+  const chordStructure = chooseChordStructure(chordType)
+  console.log("I have chosen a chord structure: " + JSON.stringify(chordStructure))
+
+  // Choose an inversion from those afforded by the chosen `ChordStructure`
   const inversion = chooseInversion(chordType)
   console.log("I have chosen an inversion: " + JSON.stringify(inversion))
   const keySignature = chooseKeySignature()

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -600,8 +600,6 @@ function chooseRootAccidental(syllable, structure, allowedAccidentals) {
  */
 export function concretizeRoot(keySignature, modeNote) {
 
-  console.log("concretize root in key signature " + keySignature + " with mode note: " + modeNote)
-
   // TODO: ask David-- how do we know accidental at the shapes level of abstraction?
   // TODO: Configure the Shapes object so we don't have iterate through an array of notes each time
   // TODO: Use this function to generate every note not just roots? If so, rename to something like concretizeNote.

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -340,7 +340,10 @@ export function partiallyConcretizeChord(chordDescription, keySignature) {
   for(var i=0; i<chordDescription.structure.structure.length; i++){
 
     // Translate the template ip to a relative note in the class
+    // FIXME: (James) I am relatively certain this is not there yet.
     const translatedNoteIP = translateNoteIPIndex(chordDescription.structure[i], rootIP)
+
+    // The syllable of the chord component
     const syllable = chordComponentSyllable(translatedNoteIP, chordDescription)
 
     // find the equivalent IP based on the rootIp and tensionMod12 value in the class
@@ -362,12 +365,13 @@ export function partiallyConcretizeChord(chordDescription, keySignature) {
     }
 
     // FIXME: (James) Add a convenience getter to Accidental to avoid the `Object.values` choreography
-    let accidental = Object.values(Accidental)[(2 + accidentalVal)%5]
+    const accidental = Object.values(Accidental)[(2 + accidentalVal)%5]
 
     // Translate the syllable "position" to a letter
     // FIXME: Add convenience getters to LetterName to avoid the `Object.values` choreography
 
-    let noteLetter = Object.values(LetterName)[Object.values(IndependentPitchSubset.BOTTOM).indexOf(syllable)]
+    const syllableIndex = Object.values(IndependentPitchSubset.BOTTOM).indexOf(syllable)
+    const noteLetter = Object.values(LetterName)[syllableIndex]
 
     // FIXME: (James) This currently requires context not injected into this function.
     //        We should do this octave adjustment after the fact, once we are put in a clef'd universe.

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -428,14 +428,6 @@ function chordComponentIndependentPitch(rootIP, translatedNoteIPIndex, keySignat
   return ips[(rootIPIndex + translatedNoteIPIndex) % 12]
 }
 
-// TODO: (David) make sure this matches with the range set in randomChoice(clefs)
-// this assumes a structure will only exceed ONE of those limits, not both. also has an "or" statement for upper limit octaves, but not lower (because chords are inverted/modified upward)
-
-// NOTE:  There is quite a bit of potential for accidential mutation here
-//        - `chord` should not be touched inside here
-//        - `adjust` could be _adjusted_ by many things and it feels quite brittle
-//
-
 /**
  * range - returns range of acceptable letter name + octave pairs for a given clef
  *

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -262,17 +262,15 @@ export function randomChord(options) {
 
   // Choose a `ChordType` from the constraints provided by the user
   const chordType = chooseChordType(chordTypesOption(options.chordTypes))
-  console.log("I have chosen a chord type: " + JSON.stringify(chordType))
 
   // Choose a `ChordStructure` belonging to the chosen `ChordType` family
   const chordStructure = chooseChordStructure(chordType)
-  console.log("I have chosen a chord structure: " + JSON.stringify(chordStructure))
 
   // Choose an inversion from those afforded by the chosen `ChordStructure`
   const inversion = chooseInversion(chordType)
-  console.log("I have chosen an inversion: " + JSON.stringify(inversion))
+
+  // Choose a `KeySignature`
   const keySignature = chooseKeySignature()
-  console.log("I have chosen a keySignature: " + JSON.stringify(keySignature))
 
   // Construct non—octave-positioned description of a chord, in the form:
   // {
@@ -281,8 +279,6 @@ export function randomChord(options) {
   //    inversion: Int
   // }
   const chordDescription = makeChordDescription(chordStructure, inversion, keySignature)
-
-  console.log("I have made a chordDescription: " + JSON.stringify(chordDescription))
 
   // Construct the non-octave positioned notes for chord described above
   // TODO: Come up with a better name
@@ -331,9 +327,10 @@ export function makeChordDescription(chordStructure, inversion, keySignature) {
  */
 function syllablePosition(rootSyllable, translatedNoteIP, keySignature) {
   // The array of the "Bottom" modes in-order
-  const modeSubset = Object.values(ModeSubset.BOTTOM)
+  const modeSubset = Object.keys(IndependentPitchSubset.BOTTOM)
   const rootSyllableIndex = modeSubset.indexOf(rootSyllable)
-  const shape = Object.values(Shapes)[keySignature]
+  const shape = Shapes[keySignature]
+  console.log("translated note ip: " + translatedNoteIP)
   const noteOffsetInShape = shape[translatedNoteIP].tensionMod7 - 1
   return modeSubset[(rootSyllableIndex + noteOffsetInShape) % 7]  
 }
@@ -347,7 +344,7 @@ function syllablePosition(rootSyllable, translatedNoteIP, keySignature) {
 function componentIP(rootIP, translatedNoteIP, keySignature) {
   const ips = Object.values(IndependentPitch)
   const rootIPIndex = ips.indexOf(rootIP)
-  const shape = Object.values(Shapes)[keySignature]
+  const shape = Shapes[keySignature]
   const noteOffsetInShape = shape[translatedNoteIP].tensionMod12 - 1
   return ips[(rootIPIndex + noteOffsetInShape) % 12]
 }

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -347,11 +347,11 @@ export function partiallyConcretizeChord(chordDescription, keySignature) {
     const syllable = chordComponentSyllable(translatedNoteIP, chordDescription)
 
     // find the equivalent IP based on the rootIp and tensionMod12 value in the class
-    let noteIP = chordComponentIndependentPitch(rootIP, translatedNoteIP, keySignature)
+    const noteIP = chordComponentIndependentPitch(rootIP, translatedNoteIP, keySignature)
 
     // FIXME: (James) Make a helper function that tidies this up
     // find the accidental from the diff between IP and "natural" syllable (natural is accidentals[2])
-    let accidentalVal = (Object.values(IndependentPitch).indexOf(noteIP))-(Object.values(IndependentPitch).indexOf(syllable))
+    const accidentalVal = (Object.values(IndependentPitch).indexOf(noteIP))-(Object.values(IndependentPitch).indexOf(syllable))
 
     // FIXME: (James) Perhaps break this into a function of its own
     // FIXME: Add convenience getters to IndependentPitch to avoid the `Object.values` choreography

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -338,19 +338,15 @@ export function partiallyConcretizeChord(chordDescription, keySignature) {
   // FIXME: Assess schema (diving `structure.structure` is not elegant)
   for(var i=0; i<chordDescription.structure.structure.length; i++){
 
-    // translate the template ip to a relative note in the class
+    // Translate the template ip to a relative note in the class
     const translatedNoteIP = translateNoteIPIndex(chordDescription.structure[i], rootIP)
-
-    console.log("translatedNoteIP: " + JSON.stringify(translatedNoteIP))
-
-    const _noteSyllable = syllable(translatedNoteIP, chordDescription)
-    console.log("_syllablePosition: " + JSON.stringify(_noteSyllable))
+    const syllable = chordComponentSyllable(translatedNoteIP, chordDescription)
 
     // find the equivalent IP based on the rootIp and tensionMod12 value in the class
-    let noteIP = componentIP(rootIP, translatedNoteIP, keySignature)
+    let noteIP = chordComponentIndependentPitch(rootIP, translatedNoteIP, keySignature)
 
     // find the accidental from the diff between IP and "natural" syllable (natural is accidentals[2])
-    let accidentalVal = (Object.values(IndependentPitch).indexOf(noteIP))-(Object.values(IndependentPitch).indexOf(noteSyllable))
+    let accidentalVal = (Object.values(IndependentPitch).indexOf(noteIP))-(Object.values(IndependentPitch).indexOf(syllable))
 
     // FIXME: (James) Perhaps break this into a function of its own
     // FIXME: Add convenience getters to IndependentPitch to avoid the `Object.values` choreography
@@ -368,7 +364,7 @@ export function partiallyConcretizeChord(chordDescription, keySignature) {
 
     // Translate the syllable "position" to a letter
     // FIXME: Add convenience getters to LetterName to avoid the `Object.values` choreography
-    let noteLetter = Object.values(LetterName)[Object.values(ModeSubset.BOTTOM).indexOf(noteSyllable)]
+    let noteLetter = Object.values(LetterName)[Object.values(ModeSubset.BOTTOM).indexOf(syllable)]
 
     // FIXME: (James) This currently requires context not injected into this function.
     //        We should do this octave adjustment after the fact, once we are put in a clef'd universe.
@@ -395,7 +391,7 @@ export function partiallyConcretizeChord(chordDescription, keySignature) {
 }
 
 
-function syllable(translatedNoteIPIndex, chordDescription) {
+function chordComponentSyllable(translatedNoteIPIndex, chordDescription) {
   // FIXME: Come up with a name that is neither `whiteNotes` or `.BOTTOM`
   const whiteNotes = Object.values(IndependentPitchSubset.BOTTOM)
   const rootSyllable = chordDescription.root.syllable
@@ -413,7 +409,7 @@ function syllable(translatedNoteIPIndex, chordDescription) {
  * @param keySignature      KeySignature      The KeySignature context of the chord
  */
 // find the equivalent IP based on the rootIp and tensionMod12 value in the class
-function componentIP(rootIP, translatedNoteIP, keySignature) {
+function chordComponentIndependentPitch(rootIP, translatedNoteIP, keySignature) {
   const ips = Object.values(IndependentPitch)
   const rootIPIndex = ips.indexOf(rootIP)
   const shape = Shapes[keySignature]

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -319,36 +319,6 @@ export function makeChordDescription(chordStructure, inversion, keySignature) {
   }
 }
 
-// get the syllable "position" from the reference subset based on tensionMod7 value in the class
-/**
- * @param rootSyllable      IndependentPitch  The IndependentPitch syllable of the root of a chord
- * @param translatedNoteIP  IndependentPitch  The IndependentPitch syllable of the chord component
- * @param keySignature      KeySignature      The KeySignature context of the chord
- */
-function syllablePosition(rootSyllable, translatedNoteIP, keySignature) {
-  // The array of the "Bottom" modes in-order
-  const modeSubset = Object.keys(IndependentPitchSubset.BOTTOM)
-  const rootSyllableIndex = modeSubset.indexOf(rootSyllable)
-  const shape = Shapes[keySignature]
-  console.log("translated note ip: " + translatedNoteIP)
-  const noteOffsetInShape = shape[translatedNoteIP].tensionMod7 - 1
-  return modeSubset[(rootSyllableIndex + noteOffsetInShape) % 7]  
-}
-
-/**
- * @param rootIP            IndependentPitch  The IndependentPitch syllable of the root of a chord
- * @param translatedNoteIP  IndependentPitch  The IndependentPitch syllable of the chord component
- * @param keySignature      KeySignature      The KeySignature context of the chord
- */
-// find the equivalent IP based on the rootIp and tensionMod12 value in the class
-function componentIP(rootIP, translatedNoteIP, keySignature) {
-  const ips = Object.values(IndependentPitch)
-  const rootIPIndex = ips.indexOf(rootIP)
-  const shape = Shapes[keySignature]
-  const noteOffsetInShape = shape[translatedNoteIP].tensionMod12 - 1
-  return ips[(rootIPIndex + noteOffsetInShape) % 12]
-}
-
 /**
  * partiallyConcretizeChord - Return the non-octave-positioned notes for the given `chord`.
  * @param chordDescription
@@ -420,6 +390,37 @@ export function partiallyConcretizeChord(chordDescription, keySignature) {
 
   return notes
 }
+
+// get the syllable "position" from the reference subset based on tensionMod7 value in the class
+/**
+ * @param rootSyllable      IndependentPitch  The IndependentPitch syllable of the root of a chord
+ * @param translatedNoteIP  IndependentPitch  The IndependentPitch syllable of the chord component
+ * @param keySignature      KeySignature      The KeySignature context of the chord
+ */
+function syllablePosition(rootSyllable, translatedNoteIP, keySignature) {
+  // The array of the "Bottom" modes in-order
+  const modeSubset = Object.keys(IndependentPitchSubset.BOTTOM)
+  const rootSyllableIndex = modeSubset.indexOf(rootSyllable)
+  const shape = Shapes[keySignature]
+  console.log("translated note ip: " + translatedNoteIP)
+  const noteOffsetInShape = shape[translatedNoteIP].tensionMod7 - 1
+  return modeSubset[(rootSyllableIndex + noteOffsetInShape) % 7]  
+}
+
+/**
+ * @param rootIP            IndependentPitch  The IndependentPitch syllable of the root of a chord
+ * @param translatedNoteIP  IndependentPitch  The IndependentPitch syllable of the chord component
+ * @param keySignature      KeySignature      The KeySignature context of the chord
+ */
+// find the equivalent IP based on the rootIp and tensionMod12 value in the class
+function componentIP(rootIP, translatedNoteIP, keySignature) {
+  const ips = Object.values(IndependentPitch)
+  const rootIPIndex = ips.indexOf(rootIP)
+  const shape = Shapes[keySignature]
+  const noteOffsetInShape = shape[translatedNoteIP].tensionMod12 - 1
+  return ips[(rootIPIndex + noteOffsetInShape) % 12]
+}
+
 
 // TODO: (David) make sure this matches with the range set in randomChoice(clefs)
 // this assumes a structure will only exceed ONE of those limits, not both. also has an "or" statement for upper limit octaves, but not lower (because chords are inverted/modified upward)

--- a/src/tests/Accidental.test.js
+++ b/src/tests/Accidental.test.js
@@ -1,0 +1,21 @@
+import { Accidental, distanceFromNatural } from '../generator/Accidental'
+
+test('Accidental offset does not blow up', () => {
+	expect(Accidental.offset(Accidental.DOUBLEFLAT)).toBe(0)
+	expect(Accidental.offset(Accidental.FLAT)).toBe(1)
+	expect(Accidental.offset(Accidental.NATURAL)).toBe(2)
+	expect(Accidental.offset(Accidental.SHARP)).toBe(3)
+	expect(Accidental.offset(Accidental.DOUBLESHARP)).toBe(4)
+})
+
+test('Natural has a 0 distance from natural', () => {
+	expect(distanceFromNatural(Accidental.NATURAL)).toBe(0)
+})
+
+test('Sharp has a 1 distance from natural', () => {
+	expect(distanceFromNatural(Accidental.SHARP)).toBe(1)
+})
+
+test('Doubleflat has a -2 distance from natural', () => {
+	expect(distanceFromNatural(Accidental.DOUBLEFLAT)).toBe(-2)
+})

--- a/src/tests/Accidental.test.js
+++ b/src/tests/Accidental.test.js
@@ -9,13 +9,13 @@ test('Accidental offset does not blow up', () => {
 })
 
 test('Natural has a 0 distance from natural', () => {
-	expect(distanceFromNatural(Accidental.NATURAL)).toBe(0)
+	expect(Accidental.offsetFromNatural(Accidental.NATURAL)).toBe(0)
 })
 
 test('Sharp has a 1 distance from natural', () => {
-	expect(distanceFromNatural(Accidental.SHARP)).toBe(1)
+	expect(Accidental.offsetFromNatural(Accidental.SHARP)).toBe(1)
 })
 
 test('Doubleflat has a -2 distance from natural', () => {
-	expect(distanceFromNatural(Accidental.DOUBLEFLAT)).toBe(-2)
+	expect(Accidental.offsetFromNatural(Accidental.DOUBLEFLAT)).toBe(-2)
 })

--- a/src/tests/makeChord.test.js
+++ b/src/tests/makeChord.test.js
@@ -50,11 +50,11 @@ test('concretizeRoot returns DO NATURAL for MAJOR mode note in C major', () => {
   expect(concretizedRoot.accidental).toBe(Accidental.NATURAL)
 })
 
-test('concretizeRoot returns XXX FLAT for MAJOR mode note in F major', () => {
+test('concretizeRoot returns KE FLAT for MAJOR mode note in F major', () => {
   const keySignature = 'R1' /*B means bottom shape*/
   const modeNote = Mode.LYDIAN
   const concretizedRoot = concretizeRoot(keySignature, modeNote)
-  expect(concretizedRoot.independentPitch).toBe(IndependentPitch.TI)
+  expect(concretizedRoot.independentPitch).toBe(IndependentPitch.KE)
   expect(concretizedRoot.accidental).toBe(Accidental.FLAT)
 })
 

--- a/src/tests/randomChord.test.js
+++ b/src/tests/randomChord.test.js
@@ -120,7 +120,7 @@ test('concretizeRoot d natural in D', () => {
 })
 
 test('concretizeRoot f natural in d', () => {
-  const keySignature = 'R1' // D major
+  const keySignature = 'R1' // d min
   const modeNote = 'Maj'
   const expected = {
     independentPitch: IndependentPitch.FA,

--- a/src/tests/randomChord.test.js
+++ b/src/tests/randomChord.test.js
@@ -1,10 +1,13 @@
 import { 
 	randomChord, 
+	chooseChordType,
 	chooseChordStructure, 
 	chooseInversion,
-	chooseKeySignature
+	chooseKeySignature,
+	makeChordDescription
 } from '../generator/chordGenerator'
 import { ChordType } from '../generator/ChordType'
+import { ChordTypesOption } from '../generator/ChordTypesOption'
 
 test('chooseChordStructure returns a value for all valid inputs', () => {
 	expect(chooseChordStructure(ChordType.TRIAD)).toBeDefined()
@@ -19,6 +22,13 @@ test('chooseInversion returns a value for all valid inputs', () => {
 
 test('chooseKeySignature returns something', () => {
 	expect(chooseKeySignature()).toBeDefined()
+})
+
+test('makeChordDescription makes a chordDescription', () => {
+	const chordType = chooseChordType(ChordTypesOption.BOTH)
+	const inversion = chooseInversion(chordType)
+	const keySignature = chooseKeySignature()
+	expect(makeChordDescription(chordType, inversion, keySignature)).toBeDefined()
 })
 
 test('randomChord does not blow up', () => {

--- a/src/tests/randomChord.test.js
+++ b/src/tests/randomChord.test.js
@@ -67,7 +67,7 @@ test('partially concretize major chord on c natural in root position in c major'
   // TODO: Actually check logic, please.
 })
 
-test('concretizeRoot c natural in c', () => {
+test('concretizeRoot c natural in C', () => {
   const keySignature = 'B' // "Bottom", i.e., C major
   const modeNote = 'Maj'
   const expected = {
@@ -75,6 +75,58 @@ test('concretizeRoot c natural in c', () => {
     accidental: Accidental.NATURAL,
     letter: LetterName.C,
     syllable: IndependentPitch.DO
+  }
+  const result = concretizeRoot(keySignature, modeNote)
+  expect(result).toStrictEqual(expected)
+})
+
+test('concretizeRoot e natural in C', () => {
+  const keySignature = 'B' // "Bottom", i.e., C major
+  const modeNote = 'phr'
+  const expected = {
+    independentPitch: IndependentPitch.MI,
+    accidental: Accidental.NATURAL,
+    letter: LetterName.E,
+    syllable: IndependentPitch.MI
+  }
+  const result = concretizeRoot(keySignature, modeNote)
+  expect(result).toStrictEqual(expected)
+})
+
+test('concretizeRoot g natural in C', () => {
+  const keySignature = 'B' // "Bottom", i.e., C major
+  const modeNote = 'Dom'
+  const expected = {
+    independentPitch: IndependentPitch.SO,
+    accidental: Accidental.NATURAL,
+    letter: LetterName.G,
+    syllable: IndependentPitch.SO
+  }
+  const result = concretizeRoot(keySignature, modeNote)
+  expect(result).toStrictEqual(expected)
+})
+
+test('concretizeRoot d natural in D', () => {
+  const keySignature = 'L2' // D major
+  const modeNote = 'Maj'
+  const expected = {
+    independentPitch: IndependentPitch.RE,
+    accidental: Accidental.NATURAL,
+    letter: LetterName.D,
+    syllable: IndependentPitch.RE
+  }
+  const result = concretizeRoot(keySignature, modeNote)
+  expect(result).toStrictEqual(expected)
+})
+
+test('concretizeRoot f natural in d', () => {
+  const keySignature = 'R1' // D major
+  const modeNote = 'Maj'
+  const expected = {
+    independentPitch: IndependentPitch.FA,
+    accidental: Accidental.NATURAL,
+    letter: LetterName.F,
+    syllable: IndependentPitch.FA
   }
   const result = concretizeRoot(keySignature, modeNote)
   expect(result).toStrictEqual(expected)

--- a/src/tests/randomChord.test.js
+++ b/src/tests/randomChord.test.js
@@ -4,7 +4,8 @@ import {
 	chooseChordStructure, 
 	chooseInversion,
 	chooseKeySignature,
-	makeChordDescription
+	makeChordDescription,
+	partiallyConcretizeChord
 } from '../generator/chordGenerator'
 import { ChordType } from '../generator/ChordType'
 import { ChordTypesOption } from '../generator/ChordTypesOption'
@@ -31,6 +32,14 @@ test('makeChordDescription makes a chordDescription', () => {
 	expect(makeChordDescription(chordType, inversion, keySignature)).toBeDefined()
 })
 
+test('partially concretize chord notes makes three notes for a triad', () => {
+	const chordType = ChordType.TRIAD
+	const inversion = chooseInversion(chordType)
+	const keySignature = chooseKeySignature()
+	const chordDescription = makeChordDescription(chordType, inversion, keySignature)	
+	expect(partiallyConcretizeChord(chordDescription, keySignature).length).toBe(3)
+})
+
 test('randomChord does not blow up', () => {
   const options = {
     chordTypes: { triads: true, sevenths: true },
@@ -44,4 +53,3 @@ test('partially concretize chord does something', () => {
   const keySignature = { }
     
 })
-

--- a/src/tests/randomChord.test.js
+++ b/src/tests/randomChord.test.js
@@ -1,4 +1,11 @@
-import { randomChord } from '../generator/chordGenerator'
+import { randomChord, chooseChordStructure } from '../generator/chordGenerator'
+import { ChordType } from '../generator/ChordType'
+
+test('chooseChordStructure returns a value for all valid inputs', () => {
+	expect(chooseChordStructure(ChordType.TRIAD)).toBeDefined()
+	expect(chooseChordStructure(ChordType.SEVENTH)).toBeDefined()
+	// TODO: Add tests for borrowed and applied chords
+})
 
 test('randomChord does not blow up', () => {
   const options = {

--- a/src/tests/randomChord.test.js
+++ b/src/tests/randomChord.test.js
@@ -1,13 +1,13 @@
 import { 
-	randomChord, 
-	chooseChordType,
-	chooseChordStructure, 
-	chooseInversion,
-	chooseKeySignature,
-	randomRomanNumeralContext,
-	makeChordDescription,
-	partiallyConcretizeChord,
-	concretizeRoot
+  randomChord, 
+  chooseChordType,
+  chooseChordStructure, 
+  chooseInversion,
+  chooseKeySignature,
+  randomRomanNumeralContext,
+  makeChordDescription,
+  partiallyConcretizeChord,
+  concretizeRoot
 } from '../generator/chordGenerator'
 import { IndependentPitch } from '../generator/IP'
 import { Accidental } from '../generator/Accidental'
@@ -17,67 +17,67 @@ import { ChordTypesOption } from '../generator/ChordTypesOption'
 import { ChordStructure } from '../generator/ChordStructure'
 
 test('chooseChordStructure returns a value for all valid inputs', () => {
-	expect(chooseChordStructure(ChordType.TRIAD)).toBeDefined()
-	expect(chooseChordStructure(ChordType.SEVENTH)).toBeDefined()
-	// TODO: Add tests for borrowed and applied chords
+  expect(chooseChordStructure(ChordType.TRIAD)).toBeDefined()
+  expect(chooseChordStructure(ChordType.SEVENTH)).toBeDefined()
+  // TODO: Add tests for borrowed and applied chords
 })
 
 test('chooseInversion returns a value for all valid inputs', () => {
-	expect(chooseInversion(ChordType.TRIAD)).toBeDefined()
-	expect(chooseInversion(ChordType.SEVENTH)).toBeDefined()
+  expect(chooseInversion(ChordType.TRIAD)).toBeDefined()
+  expect(chooseInversion(ChordType.SEVENTH)).toBeDefined()
 })
 
 test('chooseKeySignature returns something', () => {
-	expect(chooseKeySignature()).toBeDefined()
+  expect(chooseKeySignature()).toBeDefined()
 })
 
 test('makeChordDescription makes a chordDescription', () => {
-	const chordType = chooseChordType(ChordTypesOption.BOTH)
-	const chordStructure = chooseChordStructure(chordType)
-	const inversion = chooseInversion(chordType)
-	const keySignature = chooseKeySignature()
-	const romanNumeralContext = randomRomanNumeralContext(chordStructure)
-	const chordDescription = makeChordDescription(chordStructure, inversion, keySignature, romanNumeralContext)
-	expect(chordDescription).toBeDefined()
+  const chordType = chooseChordType(ChordTypesOption.BOTH)
+  const chordStructure = chooseChordStructure(chordType)
+  const inversion = chooseInversion(chordType)
+  const keySignature = chooseKeySignature()
+  const romanNumeralContext = randomRomanNumeralContext(chordStructure)
+  const chordDescription = makeChordDescription(chordStructure, inversion, keySignature, romanNumeralContext)
+  expect(chordDescription).toBeDefined()
 })
 
 test('partially concretize chord notes makes three notes for a triad', () => {
-	const chordType = ChordType.TRIAD
-	const chordStructure = chooseChordStructure(chordType)
-	const inversion = chooseInversion(chordType)
-	const keySignature = chooseKeySignature()
-	const romanNumeralContext = randomRomanNumeralContext(chordStructure)
-	const chordDescription = makeChordDescription(chordStructure, inversion, keySignature, romanNumeralContext)	
-	expect(partiallyConcretizeChord(chordDescription, keySignature).length).toBe(3)
+  const chordType = ChordType.TRIAD
+  const chordStructure = chooseChordStructure(chordType)
+  const inversion = chooseInversion(chordType)
+  const keySignature = chooseKeySignature()
+  const romanNumeralContext = randomRomanNumeralContext(chordStructure)
+  const chordDescription = makeChordDescription(chordStructure, inversion, keySignature, romanNumeralContext) 
+  expect(partiallyConcretizeChord(chordDescription, keySignature).length).toBe(3)
 })
 
 test('partially concretize major chord on c natural in root position in c major', () => {
-	const chordStructure = ChordStructure.MAJOR
-	const inversion = ""
-	const keySignature = 'B' // "Bottom", i.e., C major
-	const romanNumeralContext = {
-		"mode": "Maj",
-		"modeNote": "Maj",
-		"degree": 1,
-		"romanNumeral": "I"
-	}
-	const chordDescription = makeChordDescription(chordStructure, inversion, keySignature, romanNumeralContext)
-	const partiallyConcretized = partiallyConcretizeChord(chordDescription, keySignature)
-	expect(partiallyConcretized.length).toBe(3)
-	// TODO: Actually check logic, please.
+  const chordStructure = ChordStructure.MAJOR
+  const inversion = ""
+  const keySignature = 'B' // "Bottom", i.e., C major
+  const romanNumeralContext = {
+    "mode": "Maj",
+    "modeNote": "Maj",
+    "degree": 1,
+    "romanNumeral": "I"
+  }
+  const chordDescription = makeChordDescription(chordStructure, inversion, keySignature, romanNumeralContext)
+  const partiallyConcretized = partiallyConcretizeChord(chordDescription, keySignature)
+  expect(partiallyConcretized.length).toBe(3)
+  // TODO: Actually check logic, please.
 })
 
 test('concretizeRoot c natural in c', () => {
-	const keySignature = 'B' // "Bottom", i.e., C major
-	const modeNote = 'Maj'
-	const expected = {
-		independentPitch: IndependentPitch.DO,
-		accidental: Accidental.NATURAL,
-		letter: LetterName.C,
-		syllable: IndependentPitch.DO
-	}
-	const result = concretizeRoot(keySignature, modeNote)
-	expect(result).toStrictEqual(expected)
+  const keySignature = 'B' // "Bottom", i.e., C major
+  const modeNote = 'Maj'
+  const expected = {
+    independentPitch: IndependentPitch.DO,
+    accidental: Accidental.NATURAL,
+    letter: LetterName.C,
+    syllable: IndependentPitch.DO
+  }
+  const result = concretizeRoot(keySignature, modeNote)
+  expect(result).toStrictEqual(expected)
 })
 
 test('randomChord does not blow up', () => {

--- a/src/tests/randomChord.test.js
+++ b/src/tests/randomChord.test.js
@@ -6,8 +6,12 @@ import {
 	chooseKeySignature,
 	randomRomanNumeralContext,
 	makeChordDescription,
-	partiallyConcretizeChord
+	partiallyConcretizeChord,
+	concretizeRoot
 } from '../generator/chordGenerator'
+import { IndependentPitch } from '../generator/IP'
+import { Accidental } from '../generator/Accidental'
+import { LetterName } from '../generator/LetterName'
 import { ChordType } from '../generator/ChordType'
 import { ChordTypesOption } from '../generator/ChordTypesOption'
 import { ChordStructure } from '../generator/ChordStructure'
@@ -61,6 +65,19 @@ test('partially concretize major chord on c natural in root position in c major'
 	const partiallyConcretized = partiallyConcretizeChord(chordDescription, keySignature)
 	expect(partiallyConcretized.length).toBe(3)
 	// TODO: Actually check logic, please.
+})
+
+test('concretizeRoot c natural in c', () => {
+	const keySignature = 'B' // "Bottom", i.e., C major
+	const modeNote = 'Maj'
+	const expected = {
+		independentPitch: IndependentPitch.DO,
+		accidental: Accidental.NATURAL,
+		letter: LetterName.C,
+		syllable: IndependentPitch.DO
+	}
+	const result = concretizeRoot(keySignature, modeNote)
+	expect(result).toStrictEqual(expected)
 })
 
 test('randomChord does not blow up', () => {

--- a/src/tests/randomChord.test.js
+++ b/src/tests/randomChord.test.js
@@ -27,16 +27,18 @@ test('chooseKeySignature returns something', () => {
 
 test('makeChordDescription makes a chordDescription', () => {
 	const chordType = chooseChordType(ChordTypesOption.BOTH)
+	const chordStructure = chooseChordStructure(chordType)
 	const inversion = chooseInversion(chordType)
 	const keySignature = chooseKeySignature()
-	expect(makeChordDescription(chordType, inversion, keySignature)).toBeDefined()
+	expect(makeChordDescription(chordStructure, inversion, keySignature)).toBeDefined()
 })
 
 test('partially concretize chord notes makes three notes for a triad', () => {
 	const chordType = ChordType.TRIAD
+	const chordStructure = chooseChordStructure(chordType)
 	const inversion = chooseInversion(chordType)
 	const keySignature = chooseKeySignature()
-	const chordDescription = makeChordDescription(chordType, inversion, keySignature)	
+	const chordDescription = makeChordDescription(chordStructure, inversion, keySignature)	
 	expect(partiallyConcretizeChord(chordDescription, keySignature).length).toBe(3)
 })
 

--- a/src/tests/randomChord.test.js
+++ b/src/tests/randomChord.test.js
@@ -1,4 +1,9 @@
-import { randomChord, chooseChordStructure, chooseInversion } from '../generator/chordGenerator'
+import { 
+	randomChord, 
+	chooseChordStructure, 
+	chooseInversion,
+	chooseKeySignature
+} from '../generator/chordGenerator'
 import { ChordType } from '../generator/ChordType'
 
 test('chooseChordStructure returns a value for all valid inputs', () => {
@@ -10,6 +15,10 @@ test('chooseChordStructure returns a value for all valid inputs', () => {
 test('chooseInversion returns a value for all valid inputs', () => {
 	expect(chooseInversion(ChordType.TRIAD)).toBeDefined()
 	expect(chooseInversion(ChordType.SEVENTH)).toBeDefined()
+})
+
+test('chooseKeySignature returns something', () => {
+	expect(chooseKeySignature()).toBeDefined()
 })
 
 test('randomChord does not blow up', () => {

--- a/src/tests/randomChord.test.js
+++ b/src/tests/randomChord.test.js
@@ -4,11 +4,13 @@ import {
 	chooseChordStructure, 
 	chooseInversion,
 	chooseKeySignature,
+	randomRomanNumeralContext,
 	makeChordDescription,
 	partiallyConcretizeChord
 } from '../generator/chordGenerator'
 import { ChordType } from '../generator/ChordType'
 import { ChordTypesOption } from '../generator/ChordTypesOption'
+import { ChordStructure } from '../generator/ChordStructure'
 
 test('chooseChordStructure returns a value for all valid inputs', () => {
 	expect(chooseChordStructure(ChordType.TRIAD)).toBeDefined()
@@ -30,7 +32,9 @@ test('makeChordDescription makes a chordDescription', () => {
 	const chordStructure = chooseChordStructure(chordType)
 	const inversion = chooseInversion(chordType)
 	const keySignature = chooseKeySignature()
-	expect(makeChordDescription(chordStructure, inversion, keySignature)).toBeDefined()
+	const romanNumeralContext = randomRomanNumeralContext(chordStructure)
+	const chordDescription = makeChordDescription(chordStructure, inversion, keySignature, romanNumeralContext)
+	expect(chordDescription).toBeDefined()
 })
 
 test('partially concretize chord notes makes three notes for a triad', () => {
@@ -38,8 +42,25 @@ test('partially concretize chord notes makes three notes for a triad', () => {
 	const chordStructure = chooseChordStructure(chordType)
 	const inversion = chooseInversion(chordType)
 	const keySignature = chooseKeySignature()
-	const chordDescription = makeChordDescription(chordStructure, inversion, keySignature)	
+	const romanNumeralContext = randomRomanNumeralContext(chordStructure)
+	const chordDescription = makeChordDescription(chordStructure, inversion, keySignature, romanNumeralContext)	
 	expect(partiallyConcretizeChord(chordDescription, keySignature).length).toBe(3)
+})
+
+test('partially concretize major chord on c natural in root position in c major', () => {
+	const chordStructure = ChordStructure.MAJOR
+	const inversion = ""
+	const keySignature = 'B' // "Bottom", i.e., C major
+	const romanNumeralContext = {
+		"mode": "Maj",
+		"modeNote": "Maj",
+		"degree": 1,
+		"romanNumeral": "I"
+	}
+	const chordDescription = makeChordDescription(chordStructure, inversion, keySignature, romanNumeralContext)
+	const partiallyConcretized = partiallyConcretizeChord(chordDescription, keySignature)
+	expect(partiallyConcretized.length).toBe(3)
+	// TODO: Actually check logic, please.
 })
 
 test('randomChord does not blow up', () => {

--- a/src/tests/randomChord.test.js
+++ b/src/tests/randomChord.test.js
@@ -1,10 +1,15 @@
-import { randomChord, chooseChordStructure } from '../generator/chordGenerator'
+import { randomChord, chooseChordStructure, chooseInversion } from '../generator/chordGenerator'
 import { ChordType } from '../generator/ChordType'
 
 test('chooseChordStructure returns a value for all valid inputs', () => {
 	expect(chooseChordStructure(ChordType.TRIAD)).toBeDefined()
 	expect(chooseChordStructure(ChordType.SEVENTH)).toBeDefined()
 	// TODO: Add tests for borrowed and applied chords
+})
+
+test('chooseInversion returns a value for all valid inputs', () => {
+	expect(chooseInversion(ChordType.TRIAD)).toBeDefined()
+	expect(chooseInversion(ChordType.SEVENTH)).toBeDefined()
 })
 
 test('randomChord does not blow up', () => {


### PR DESCRIPTION
This PR adds some fixes and tests along the `randomChord` pipeline, up until the `concretizeRoot` point.

A follow-up PR will handle the smoking out of remaining issues with generating notes from the information we have up to here.