### PR TITLE
Set octave displacement for inverted chords in partiallyConcretizeChord

### DIFF
--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -260,20 +260,23 @@ export function randomChord(options) {
   // Shuffles the root note choices so they're not always in root position haha
   // shuffle(chord.questions[1].choices)
 
-  // Choose a `ChordType` from the constraints provided by the user
+  // Choose a random `ChordType` from the constraints provided by the user
   const chordType = chooseChordType(chordTypesOption(options.chordTypes))
 
-  // Choose a `ChordStructure` belonging to the chosen `ChordType` family
+  // Choose a random `ChordStructure` belonging to the chosen `ChordType` family
   const chordStructure = chooseChordStructure(chordType)
 
-  // Choose an inversion from those afforded by the chosen `ChordStructure`
+  // Choose a random inversion from those afforded by the chosen `ChordStructure`
   const inversion = chooseInversion(chordType)
 
-  // Choose a `KeySignature`
+  // Choose a random `KeySignature`
   const keySignature = chooseKeySignature()
 
-  // Choose a roman numeral context
+  // Choose a random roman numeral context
   const romanNumeralContext = randomRomanNumeralContext(chordStructure)
+
+  // Choose a random clef
+  const clef = Clef.randomElement()
 
   // Construct non—octave-positioned description of a chord, in the form:
   // {
@@ -290,7 +293,7 @@ export function randomChord(options) {
   // TODO: (James) add `inversion` method on `Chord` type
   // const inverted = handleInversion(chordDescription, inversion)
   
-  const clef = Clef.randomElement()
+  
 
   const positionedChord = staffAdjust(partiallyConcretizedChordNotes, clef)
 

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -13,6 +13,12 @@ import { ChordTypesOption } from './ChordTypesOption'
 import { ChordStructure, chordStructures } from './ChordStructure'
 import { RomanNumeral, degreeAndQualityToRomanNumeral } from './RomanNumeral'
 
+// TODO: (James) Audit this type. Is it used anywhere.
+const RootOption = {
+  ANY: "any",
+  COMMON: "common"
+}
+
 /**
  * export default - This is the interface between the generator and chord crusher or any other app
  *
@@ -288,9 +294,7 @@ export function randomChord(options) {
 
   // Construct the non-octave positioned notes for chord described above
   // TODO: Come up with a better name
-  const partiallyConcretizedChordNotes = partiallyConcretizeChord(chordDescription, keySignature)
-
-  
+  const partiallyConcretizedChordNotes = partiallyConcretizeChord(chordDescription, keySignature)  
 
   // TODO: (James) add `inversion` method on `Chord` type
   // const inverted = handleInversion(chordDescription, inversion)
@@ -332,14 +336,34 @@ export function partiallyConcretizeChord(chordDescription, keySignature) {
 
   let octaveDisplacement = 0
 
+  let template = chordDescription.structure.structure
+  const inversion = chordDescription.inversion
+
+  console.log("inversion: " + JSON.stringify(inversion))
+
+  // inverts the chord, reorders chord.notes, and adjusts the ordered answer for inversion
+  if ((inversion === "63") || (inversion === "65")) {
+    template.rotate(1)
+    // chord.notes = invert(chord.notes, 1)
+    // chord.questions[0].answers.rotate(1)
+  } else if ((inversion === "64") || (inversion === "43")) {
+    template.rotate(2)
+    // chord.notes = invert(chord.notes, 2)
+    // chord.questions[0].answers.rotate(2)
+  } else if (inversion === "42") {
+    template.rotate(3)
+    // chord.notes = invert(chord.notes, 3)
+    // chord.questions[0].answers.rotate(3)
+  }
+
   // build the structure with correct spellings
   // FIXME: Assess schema (diving `structure.structure` is not elegant)
   // TODO: Consider breaking out the body of this loop into its own function
-  for(var i=0; i<chordDescription.structure.structure.length; i++){
+  for(var i=0; i<template.length; i++){
 
     // Translate the template ip to a relative note in the class
     // FIXME: (James) Again, the `structure.structure` ain't pretty
-    const translatedNoteIP = translateNoteIPIndex(chordDescription.structure.structure[i], rootIP)
+    const translatedNoteIP = translateNoteIPIndex(template[i], rootIP)
 
     // The syllable of the chord component
     const syllable = chordComponentSyllable(translatedNoteIP, chordDescription)
@@ -528,15 +552,6 @@ function octaveTranspose(notes, octaves) {
     return { letter: note.letter, octave: note.octave + octaves }
   })
 }
-
-
-
-const RootOption = {
-  ANY: "any",
-  COMMON: "common"
-}
-
-
 
 // Constrains accidental only for root pitch
 function constrainAccidental(syllable, structure, initialChoice) {

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -290,10 +290,10 @@ export function randomChord(options) {
   // TODO: Come up with a better name
   const partiallyConcretizedChordNotes = partiallyConcretizeChord(chordDescription, keySignature)
 
+  console.log(partiallyConcretizedChordNotes)
+
   // TODO: (James) add `inversion` method on `Chord` type
   // const inverted = handleInversion(chordDescription, inversion)
-  
-  
 
   const positionedChord = staffAdjust(partiallyConcretizedChordNotes, clef)
 
@@ -308,8 +308,6 @@ export function makeChordDescription(chordStructure, inversion, keySignature, ro
   // Concretize the root by situating the roman numeral context's `modeNote` in the given 
   // `keySignature`.
   const concretizedRoot = concretizeRoot(keySignature, romanNumeralContext.modeNote)
-
-  // TODO: Fix this return... no longer correct... (11/15)
   return {
     root: concretizedRoot,
     structure: chordStructure,

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -290,7 +290,7 @@ export function randomChord(options) {
   // TODO: Come up with a better name
   const partiallyConcretizedChordNotes = partiallyConcretizeChord(chordDescription, keySignature)
 
-  console.log(partiallyConcretizedChordNotes)
+  
 
   // TODO: (James) add `inversion` method on `Chord` type
   // const inverted = handleInversion(chordDescription, inversion)
@@ -330,6 +330,8 @@ export function partiallyConcretizeChord(chordDescription, keySignature) {
   // TODO: Consider implementing this with `map`
   let notes = []
 
+  let octaveDisplacement = 0
+
   // build the structure with correct spellings
   // FIXME: Assess schema (diving `structure.structure` is not elegant)
   // TODO: Consider breaking out the body of this loop into its own function
@@ -360,7 +362,7 @@ export function partiallyConcretizeChord(chordDescription, keySignature) {
     // }
 
     // FIXME: Use the code above with the correct context to set this variable correctly
-    const octave = 4
+    const octave = octaveDisplacement
 
     // Create the note with all of our nice new data
     const note = { letter: noteLetter, accidental: accidental(noteIP, syllable), octave: octave }

--- a/src/tests/randomChord.test.js
+++ b/src/tests/randomChord.test.js
@@ -71,6 +71,26 @@ test('partially concretize major chord on c natural in root position in c major'
   expect(partiallyConcretized).toStrictEqual(expected)
 })
 
+test('partially concretize G major chord octaves', () => {
+  const chordStructure = ChordStructure.MAJOR
+  const inversion = ""
+  const keySignature = 'L1' // G major
+  const romanNumeralContext = {
+    "mode": "Maj",
+    "modeNote": "Maj",
+    "degree": 1,
+    "romanNumeral": "I"
+  }
+  const chordDescription = makeChordDescription(chordStructure, inversion, keySignature, romanNumeralContext)
+  const partiallyConcretized = partiallyConcretizeChord(chordDescription, keySignature)
+  const expected = [
+    { "letter": "G", "accidental": "♮", "octave": 0 },
+    { "letter": "B", "accidental": "♮", "octave": 0 },
+    { "letter": "D", "accidental": "♮", "octave": 1 }
+  ]
+  expect(partiallyConcretized).toStrictEqual(expected)
+})
+
 test('concretizeRoot c natural in C', () => {
   const keySignature = 'B' // "Bottom", i.e., C major
   const modeNote = 'Maj'

--- a/src/tests/randomChord.test.js
+++ b/src/tests/randomChord.test.js
@@ -71,10 +71,10 @@ test('partially concretize major chord on c natural in root position in c major'
   expect(partiallyConcretized).toStrictEqual(expected)
 })
 
-test('partially concretize G major chord octaves', () => {
+test('partially concretize major chord on c natural in first inversion in c major', () => {
   const chordStructure = ChordStructure.MAJOR
-  const inversion = ""
-  const keySignature = 'L1' // G major
+  const inversion = "63"
+  const keySignature = 'B' // "Bottom", i.e., C major
   const romanNumeralContext = {
     "mode": "Maj",
     "modeNote": "Maj",
@@ -84,9 +84,9 @@ test('partially concretize G major chord octaves', () => {
   const chordDescription = makeChordDescription(chordStructure, inversion, keySignature, romanNumeralContext)
   const partiallyConcretized = partiallyConcretizeChord(chordDescription, keySignature)
   const expected = [
+    { "letter": "E", "accidental": "♮", "octave": 0 },
     { "letter": "G", "accidental": "♮", "octave": 0 },
-    { "letter": "B", "accidental": "♮", "octave": 0 },
-    { "letter": "D", "accidental": "♮", "octave": 1 }
+    { "letter": "C", "accidental": "♮", "octave": 1 }
   ]
   expect(partiallyConcretized).toStrictEqual(expected)
 })

--- a/src/tests/randomChord.test.js
+++ b/src/tests/randomChord.test.js
@@ -63,12 +63,10 @@ test('partially concretize major chord on c natural in root position in c major'
   }
   const chordDescription = makeChordDescription(chordStructure, inversion, keySignature, romanNumeralContext)
   const partiallyConcretized = partiallyConcretizeChord(chordDescription, keySignature)
-  console.log(JSON.stringify(partiallyConcretized))
-  // FIXME: Handle octave correctly
   const expected = [
-    { "letter": "C", "accidental": "♮", "octave": 4 },
-    { "letter": "E", "accidental": "♮", "octave": 4 },
-    { "letter": "G", "accidental": "♮", "octave": 4 }
+    { "letter": "C", "accidental": "♮", "octave": 0 },
+    { "letter": "E", "accidental": "♮", "octave": 0 },
+    { "letter": "G", "accidental": "♮", "octave": 0 }
   ]
   expect(partiallyConcretized).toStrictEqual(expected)
 })


### PR DESCRIPTION
This PR implements the octave displacement for each note in a partially-concretized (hydrogenated?) chord.

At the partially-concretized stage, `octave` values are either `0` or `1`. At the fully-concretized stage, they become more proper.

For example:

- C major chord in root position would have octave displacements: ```[0,0,0]```.
- C major chord in first inversion would have octave displacements: ```[0,0,1]```.
- C major chord in second inversion would have octave displacements: ```[0,1,1]```.