### PR TITLE
Generate questions from chordContext

### DIFF
--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -33,11 +33,15 @@ const RootOption = {
 export function questions(chordContext) {
 
   const rootLetter = chordContext.chordDescription.root.letter
+
+  console.log("root: " + JSON.stringify(chordContext.chordDescription.root))
+  console.log("root letter: " + rootLetter)
+
   const rootAccidental = chordContext.chordDescription.root.accidental
   const inversion = chordContext.chordDescription.inversion
   const degree = chordContext.romanNumeralContext.degree
   const roman = chordContext.romanNumeralContext.romanNumeral
-  const key = chordContext.key
+  const key = chordContext.keySignature
   const chordType = chordContext.chordType
 
   // FIXME: Infer `romanQuality` somehow?
@@ -86,7 +90,8 @@ export function questions(chordContext) {
       "type": "Roots",
       "questionText": "What's the root note?",
       "answers": [rootLetter + rootAccidental],
-      "choices": [] // will populate in the loop
+      // FIXME: Currently not filtering out naturals
+      "choices": chordContext.notes.map(note => note.letter + note.accidental)
     },
     {
       "type": "Degrees",
@@ -121,6 +126,9 @@ export function questions(chordContext) {
       "choices": romanInversionOptions
     }
   ]
+
+  console.log("root answer: " + (rootLetter + rootAccidental))
+  console.log("all notes: " + JSON.stringify(chordContext.notes))
 
   // TODO:
   // for note in template: 
@@ -233,6 +241,7 @@ export function randomChordContext(options) {
   const keySignature = chooseKeySignature()
   // Choose a random roman numeral context
   const romanNumeralContext = randomRomanNumeralContext(chordStructure)
+  console.log("roman numeral context: " + JSON.stringify(romanNumeralContext))
   // Choose a random clef
   const clef = Clef.randomElement()
   // Construct non—octave-positioned description of a chord, in the form:
@@ -251,6 +260,8 @@ export function randomChordContext(options) {
   // FIXME: Codify the relationship between "Shapes" key signatures, Common Western Notation key signatures,
   //        and Vexflow key signatures.
   const vexFlowKeySignature = keySignatures[keySignature].vexSig
+    
+  console.log("key signature: " + JSON.stringify(vexFlowKeySignature))
   // Bundle up all of the information useful to graphically represent the notes on the screen.
   // TODO: Consider bundling up all of the informational artifacts we have created along the way, e.g., 
   //       `chordDescription`, `romanNumeralContext`, etc.
@@ -580,6 +591,8 @@ function chooseRootAccidental(syllable, structure, allowedAccidentals) {
  */
 export function concretizeRoot(keySignature, modeNote) {
 
+  console.log("concretizeRoot: keySignature: " + keySignature + ", modeNote: " + JSON.stringify(modeNote))
+
   // TODO: ask David-- how do we know accidental at the shapes level of abstraction?
   // TODO: Configure the Shapes object so we don't have iterate through an array of notes each time
   // TODO: Use this function to generate every note not just roots? If so, rename to something like concretizeNote.
@@ -599,6 +612,8 @@ export function concretizeRoot(keySignature, modeNote) {
       const rootSyllableIndex = Object.values(IndependentPitch).indexOf(rootSyllable)
       const rootIPIndex = (rootSyllableIndex + offset) % 12
       const rootIP = Object.values(IndependentPitch)[rootIPIndex]
+
+      console.log("result: letter: " + rootLetter + rootAccidental)
 
       return {
         independentPitch: rootIP,

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -85,7 +85,7 @@ export function questions(chordContext) {
     {
       "type": "Roots",
       "questionText": "What's the root note?",
-      "answers": [rootLetter+rootAccidental],
+      "answers": [rootLetter + rootAccidental],
       "choices": [] // will populate in the loop
     },
     {

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -31,7 +31,130 @@ const RootOption = {
  * @returns             An array of questions (and answers) for the given `chordContext`.
  */
 export function questions(chordContext) {
-  // TODO
+
+  const rootLetter = chordContext.chordDescription.root.letter
+  const rootAccidental = chordContext.chordDescription.root.accidental
+  const inversion = chordContext.chordDescription.inversion
+  const degree = chordContext.romanNumeralContext.degree
+  const roman = chordContext.romanNumeralContext.romanNumeral
+  const key = chordContext.key
+  const chordType = chordContext.chordType
+
+  // FIXME: Infer `romanQuality` somehow?
+  const romanQuality = "???"
+  // FIXME: Infer `inversionQuality` somehow?
+  const inversionQuality = "???"
+
+  let romanInversionOptions
+
+  // [roman + inversionQuality + " " + inversion]
+
+  if (chordType === 'triad') {
+    romanInversionOptions = [
+      roman + inversionQuality,
+      roman + inversionQuality + '63',
+      roman + inversionQuality + '64'
+    ]
+  } else if (chordType === 'seventh') {
+    romanInversionOptions = [
+      roman + inversionQuality,
+      roman + inversionQuality + '65',
+      roman + inversionQuality + '43',
+      roman + inversionQuality + '42'
+    ]
+  }
+
+  // TODO:
+  // // aggregate options for chord quality question
+  // let qualityOptions = []
+  // Object.keys(template).map(type => {qualityOptions.push(rootLetter + rootAccidental + type)})
+
+  // // aggregate options for inversions question
+  // let inversionOptions = []
+  // inversions.map(type => {inversionOptions.push(rootLetter + rootAccidental + newStructure + " " + type)})
+
+  // // push notes into questions before adjusting accidentals for key sig
+  // chord.questions[0].answers.push(noteLetter);
+
+
+  // // FIXME: This should be its own function
+  // // only show natural in question choices if it's an alteration from the key sig
+  // if(accidental != '♮'){
+  //   chord.questions[1].choices.push(noteLetter+accidental);
+  // }
+  // else if ((accidental === '♮') && (keySignatures[keySignature].notes[keySignatures[keySignature].notes.findIndex(function(syllable){return syllable.refIP === noteSyllable})].accidental != '♮')){
+  //   chord.questions[1].choices.push(noteLetter+'♮');
+  // }
+  // else {
+  //   chord.questions[1].choices.push(noteLetter);
+  // }
+
+  // // adjust accidentals for key sig (if an accidental is in the key sig, don't add it to the note)
+  // if(accidental === keySignatures[keySignature].notes[keySignatures[keySignature].notes.findIndex(function(syllable){return syllable.refIP === noteSyllable})].accidental){
+  //   accidental = "";
+  // }
+
+  console.log("rootLetter: " + JSON.stringify(rootLetter))
+
+  
+
+  // Consider breaking this out to a factory-type function, like:
+  // question(chordContext, type)
+  let skeleton = [
+    {
+      "type": "Names",
+      "questionText": "Name the letter positions from lowest to highest.",
+      "answers": [], // will populate in the loop
+      "ordered": true,
+      "choices": [
+          "A",
+          "B",
+          "C",
+          "D",
+          "E",
+          "F",
+          "G"
+      ]
+    },
+    {
+      "type": "Roots",
+      "questionText": "What's the root note?",
+      "answers": [rootLetter+rootAccidental],
+      "choices": [] // will populate in the loop
+    },
+    {
+      "type": "Degrees",
+      "questionText": "In a " + key + " key, what degree is this chord built on?",
+      "answers": [degree + "^"],
+      "choices": [
+          "1^",
+          "2^",
+          "3^",
+          "4^",
+          "5^",
+          "6^",
+          "7^"
+      ]
+    },
+    // {
+    //   "type": "Quality",
+    //   "questionText": "What's the chord's quality?",
+    //   "answers": [rootLetter + rootAccidental + newStructure],
+    //   "choices": qualityOptions
+    // },
+    // {
+    //   "type": "Numerals",
+    //   "questionText": "Which roman numeral describes this chord’s degree and quality?",
+    //   "answers": [roman + romanQuality],
+    //   "choices": romanOptions
+    // },
+    {
+      "type": "Inversions",
+      "questionText": "What's the inversion?",
+      "answers": [roman + inversionQuality + inversion],
+      "choices": romanInversionOptions
+    }
+  ]
   return []
 }
 
@@ -369,6 +492,7 @@ export function randomChordContext(options) {
   const result = {
     clef: clef,
     keySignature: vexFlowKeySignature,
+    chordType: chordType,
     chordDescription,
     romanNumeralContext,
     notes: staffAdjustedNotes

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -94,10 +94,6 @@ export function questions(chordContext) {
   //   accidental = "";
   // }
 
-  console.log("rootLetter: " + JSON.stringify(rootLetter))
-
-  
-
   // Consider breaking this out to a factory-type function, like:
   // question(chordContext, type)
   let skeleton = [

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -103,12 +103,14 @@ export function questions(chordContext) {
           "7^"
       ]
     },
-    // {
-    //   "type": "Quality",
-    //   "questionText": "What's the chord's quality?",
-    //   "answers": [rootLetter + rootAccidental + newStructure],
-    //   "choices": qualityOptions
-    // },
+    {
+      "type": "Quality",
+      "questionText": "What's the chord's quality?",
+      "answers": [rootLetter + rootAccidental + chordContext.chordDescription.structure.displayName],
+      "choices": [...chordStructures(chordContext.chordType)]
+        .map(structure => structure.displayName)
+        .map(quality => rootLetter + rootAccidental + quality)
+    },
     // {
     //   "type": "Numerals",
     //   "questionText": "Which roman numeral describes this chord’s degree and quality?",
@@ -123,16 +125,12 @@ export function questions(chordContext) {
     }
   ]
 
+  // // aggregate options for inversions question
+  // let inversionOptions = []
+  // inversions.map(type => {inversionOptions.push(rootLetter + rootAccidental + newStructure + " " + type)})
+
   // TODO:
   // for note in template: 
-    // // aggregate options for chord quality question
-    // let qualityOptions = []
-    // Object.keys(template).map(type => {qualityOptions.push(rootLetter + rootAccidental + type)})
-
-    // // aggregate options for inversions question
-    // let inversionOptions = []
-    // inversions.map(type => {inversionOptions.push(rootLetter + rootAccidental + newStructure + " " + type)})
-
     // // push notes into questions before adjusting accidentals for key sig
     // chord.questions[0].answers.push(noteLetter);
 

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -198,14 +198,6 @@ export default function(numQs, options) {
   console.log(chords)
   return chords
 }
-  // TODO: Shuffle questions up around these parts
-  // FIXME: (James) We need to move chord shuffling closer to the user interface layer.
-  // FIXME: (James) Let's use `shuffled` here rather than mutating our source of truth.
-  // Shuffles the root note choices so they're not always in root position haha
-  // shuffle(chord.questions[1].choices)
-
-  // This is a sample output from v1 that we aspire to generating.
-  
 
 /**
  * randomChord - A big function to generate a random, correctly spelled chord structure within 

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -144,10 +144,6 @@ export function questions(chordContext) {
     }
   ]
 
-  // // aggregate options for inversions question
-  // let inversionOptions = []
-  // inversions.map(type => {inversionOptions.push(rootLetter + rootAccidental + newStructure + " " + type)})
-
   // TODO:
   // for note in template: 
     // // push notes into questions before adjusting accidentals for key sig
@@ -170,7 +166,7 @@ export function questions(chordContext) {
     // if(accidental === keySignatures[keySignature].notes[keySignatures[keySignature].notes.findIndex(function(syllable){return syllable.refIP === noteSyllable})].accidental){
     //   accidental = "";
     // }
-    // }
+  // }
 
   return skeleton
 }

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -64,43 +64,13 @@ export function questions(chordContext) {
     ]
   }
 
-  // TODO:
-  // // aggregate options for chord quality question
-  // let qualityOptions = []
-  // Object.keys(template).map(type => {qualityOptions.push(rootLetter + rootAccidental + type)})
-
-  // // aggregate options for inversions question
-  // let inversionOptions = []
-  // inversions.map(type => {inversionOptions.push(rootLetter + rootAccidental + newStructure + " " + type)})
-
-  // // push notes into questions before adjusting accidentals for key sig
-  // chord.questions[0].answers.push(noteLetter);
-
-
-  // // FIXME: This should be its own function
-  // // only show natural in question choices if it's an alteration from the key sig
-  // if(accidental != '♮'){
-  //   chord.questions[1].choices.push(noteLetter+accidental);
-  // }
-  // else if ((accidental === '♮') && (keySignatures[keySignature].notes[keySignatures[keySignature].notes.findIndex(function(syllable){return syllable.refIP === noteSyllable})].accidental != '♮')){
-  //   chord.questions[1].choices.push(noteLetter+'♮');
-  // }
-  // else {
-  //   chord.questions[1].choices.push(noteLetter);
-  // }
-
-  // // adjust accidentals for key sig (if an accidental is in the key sig, don't add it to the note)
-  // if(accidental === keySignatures[keySignature].notes[keySignatures[keySignature].notes.findIndex(function(syllable){return syllable.refIP === noteSyllable})].accidental){
-  //   accidental = "";
-  // }
-
   // Consider breaking this out to a factory-type function, like:
   // question(chordContext, type)
   let skeleton = [
     {
       "type": "Names",
       "questionText": "Name the letter positions from lowest to highest.",
-      "answers": [], // will populate in the loop
+      "answers": chordContext.notes.map(note => note.letter),
       "ordered": true,
       "choices": [
           "A",
@@ -151,7 +121,40 @@ export function questions(chordContext) {
       "choices": romanInversionOptions
     }
   ]
-  return []
+
+  // TODO:
+  // for note in template: 
+    // // aggregate options for chord quality question
+    // let qualityOptions = []
+    // Object.keys(template).map(type => {qualityOptions.push(rootLetter + rootAccidental + type)})
+
+    // // aggregate options for inversions question
+    // let inversionOptions = []
+    // inversions.map(type => {inversionOptions.push(rootLetter + rootAccidental + newStructure + " " + type)})
+
+    // // push notes into questions before adjusting accidentals for key sig
+    // chord.questions[0].answers.push(noteLetter);
+
+
+    // // FIXME: This should be its own function
+    // // only show natural in question choices if it's an alteration from the key sig
+    // if(accidental != '♮'){
+    //   chord.questions[1].choices.push(noteLetter+accidental);
+    // }
+    // else if ((accidental === '♮') && (keySignatures[keySignature].notes[keySignatures[keySignature].notes.findIndex(function(syllable){return syllable.refIP === noteSyllable})].accidental != '♮')){
+    //   chord.questions[1].choices.push(noteLetter+'♮');
+    // }
+    // else {
+    //   chord.questions[1].choices.push(noteLetter);
+    // }
+
+    // // adjust accidentals for key sig (if an accidental is in the key sig, don't add it to the note)
+    // if(accidental === keySignatures[keySignature].notes[keySignatures[keySignature].notes.findIndex(function(syllable){return syllable.refIP === noteSyllable})].accidental){
+    //   accidental = "";
+    // }
+    // }
+
+  return skeleton
 }
 
 /**
@@ -183,68 +186,17 @@ export function questions(chordContext) {
  * @todo                  Assess the spec of the questions object which is put out by this function
  */
 export default function(numQs, options) {
-  
-  // let chords = []
-  // for (var i = 0; i < numQs; i++) {
-  //   // Create the chords for each round.
-  //   chords.push(randomChord(options))
-  //   // For each chord, generate a sequence of questions appropriate for the given chord
-  //   // TODO: Generate questions
-  // }
-
-  // Fake a chord:
-  let chord = randomChordContext(options)
-
-  chord.questions = [
-     {
-        "type": "Names",
-        "questionText": "Name the letter positions from lowest to highest.",
-        "answers": [
-           "G",
-           "B",
-           "D",
-           "F"
-        ],
-        "ordered": true,
-        "choices": [
-           {
-              "choice": "A",
-              "key": "a"
-           },
-           {
-              "choice": "B",
-              "key": "b"
-           },
-           {
-              "choice": "C",
-              "key": "c"
-           },
-           {
-              "choice": "D",
-              "key": "d"
-           },
-           {
-              "choice": "E",
-              "key": "e"
-           },
-           {
-              "choice": "F",
-              "key": "f"
-           },
-           {
-              "choice": "G",
-              "key": "g"
-           }
-        ]
-     }
-  ]
-  let chords = [chord]
-
+  let chords = []
+  for (var i = 0; i < numQs; i++) {
+    // Create the chords for each round.
+    let chordContext = randomChordContext(options)
+    chordContext.questions = questions(chordContext)  
+    chords.push(chordContext)
+  }
+  addKeystrokes(chords)
+  console.log(chords)
   return chords
-
-  // TODO: Add keyStrokes
-  // return addKeystrokes(chords)
-
+}
   // TODO: Shuffle questions up around these parts
   // FIXME: (James) We need to move chord shuffling closer to the user interface layer.
   // FIXME: (James) Let's use `shuffled` here rather than mutating our source of truth.
@@ -252,190 +204,7 @@ export default function(numQs, options) {
   // shuffle(chord.questions[1].choices)
 
   // This is a sample output from v1 that we aspire to generating.
-  return [
-   {
-      "clef": "treble",
-      "keySignature": "F",
-      "notes": [
-         {
-            "letter": "G",
-            "accidental": "",
-            "octave": 4
-         },
-         {
-            "letter": "B",
-            "accidental": "",
-            "octave": 4
-         },
-         {
-            "letter": "D",
-            "accidental": "",
-            "octave": 5
-         },
-         {
-            "letter": "F",
-            "accidental": "",
-            "octave": 5
-         }
-      ],
-      "questions": [
-         {
-            "type": "Names",
-            "questionText": "Name the letter positions from lowest to highest.",
-            "answers": [
-               "G",
-               "B",
-               "D",
-               "F"
-            ],
-            "ordered": true,
-            "choices": [
-               {
-                  "choice": "A",
-                  "key": "a"
-               },
-               {
-                  "choice": "B",
-                  "key": "b"
-               },
-               {
-                  "choice": "C",
-                  "key": "c"
-               },
-               {
-                  "choice": "D",
-                  "key": "d"
-               },
-               {
-                  "choice": "E",
-                  "key": "e"
-               },
-               {
-                  "choice": "F",
-                  "key": "f"
-               },
-               {
-                  "choice": "G",
-                  "key": "g"
-               }
-            ]
-         },
-         {
-            "type": "Roots",
-            "questionText": "What's the root note?",
-            "answers": [
-               "G"
-            ],
-            "choices": [
-               {
-                  "choice": "D",
-                  "key": "d"
-               },
-               {
-                  "choice": "B♭",
-                  "key": "b"
-               },
-               {
-                  "choice": "F",
-                  "key": "f"
-               },
-               {
-                  "choice": "G",
-                  "key": "g"
-               }
-            ]
-         },
-         {
-            "type": "Degrees",
-            "questionText": "In a minor key, what degree is this chord built on?",
-            "answers": [
-               "4^"
-            ],
-            "choices": [
-               {
-                  "choice": "1^",
-                  "key": "1"
-               },
-               {
-                  "choice": "2^",
-                  "key": "2"
-               },
-               {
-                  "choice": "3^",
-                  "key": "3"
-               },
-               {
-                  "choice": "4^",
-                  "key": "4"
-               },
-               {
-                  "choice": "5^",
-                  "key": "5"
-               },
-               {
-                  "choice": "6^",
-                  "key": "6"
-               },
-               {
-                  "choice": "7^",
-                  "key": "7"
-               }
-            ]
-         },
-         {
-            "type": "Numerals",
-            "questionText": "Which roman numeral describes this chord’s degree and quality?",
-            "answers": [
-               "iv7"
-            ],
-            "choices": [
-               {
-                  "choice": "IV7",
-                  "key": "7"
-               },
-               {
-                  "choice": "iv7",
-                  "key": "m"
-               },
-               {
-                  "choice": "ivø7",
-                  "key": "h"
-               },
-               {
-                  "choice": "ivo7",
-                  "key": "d"
-               }
-            ]
-         },
-         {
-            "type": "Inversions",
-            "questionText": "What's the inversion?",
-            "answers": [
-               "iv"
-            ],
-            "choices": [
-               {
-                  "choice": "iv",
-                  "key": "r"
-               },
-               {
-                  "choice": "iv65",
-                  "key": "5"
-               },
-               {
-                  "choice": "iv43",
-                  "key": "3"
-               },
-               {
-                  "choice": "iv42",
-                  "key": "2"
-               }
-            ]
-         }
-      ]
-   }
- ]
-}
+  
 
 /**
  * randomChord - A big function to generate a random, correctly spelled chord structure within 

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -46,6 +46,26 @@ export function questions(chordContext) {
   const inversionQuality = "???"
 
   // TODO: Wrap up in own function
+
+  // roman numeral question options
+  let romanOptions
+  if (chordType === 'triad') {
+    romanOptions = [
+      roman.toUpperCase(),
+      roman.toLowerCase(),
+      roman.toLowerCase() + 'o',
+      roman.toUpperCase() + '+'
+    ]
+  }
+  if (chordType === 'seventh') {
+    romanOptions = [
+      roman.toUpperCase() + '7',
+      roman.toLowerCase() + '7',
+      roman.toLowerCase() + 'ø7',
+      roman.toLowerCase() + 'o7'
+    ]
+  }
+  
   let romanInversionOptions
   // [roman + inversionQuality + " " + inversion]
   if (chordType === 'triad') {
@@ -110,12 +130,12 @@ export function questions(chordContext) {
         .map(structure => structure.displayName)
         .map(quality => rootLetter + rootAccidental + quality)
     },
-    // {
-    //   "type": "Numerals",
-    //   "questionText": "Which roman numeral describes this chord’s degree and quality?",
-    //   "answers": [roman + romanQuality],
-    //   "choices": romanOptions
-    // },
+    {
+      "type": "Numerals",
+      "questionText": "Which roman numeral describes this chord’s degree and quality?",
+      "answers": [roman + romanQuality],
+      "choices": romanOptions
+    },
     {
       "type": "Inversions",
       "questionText": "What's the inversion?",

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -20,6 +20,22 @@ const RootOption = {
 }
 
 /**
+ * @param chordContext  Object Object in the form:
+ *                      {
+ *                        clef,
+ *                        keySignature
+ *                        chordDescription,
+ *                        romanNumeralContext,
+ *                        notes
+*                       }
+ * @returns             An array of questions (and answers) for the given `chordContext`.
+ */
+export function questions(chordContext) {
+  // TODO
+  return []
+}
+
+/**
  * export default - This is the interface between the generator and chord crusher or any other app
  *
  * @param  Int numQs      The number of questions a student has asked for
@@ -48,13 +64,65 @@ const RootOption = {
  * @todo                  Assess the spec of the questions object which is put out by this function
  */
 export default function(numQs, options) {
-  let chords = []
-  for (var i = 0; i < numQs; i++) {
-    // Create the chords for each round.
-    chords.push(randomChord(options))
-    // For each chord, generate a sequence of questions appropriate for the given chord
-    // TODO: Generate questions
-  }
+  
+  // let chords = []
+  // for (var i = 0; i < numQs; i++) {
+  //   // Create the chords for each round.
+  //   chords.push(randomChord(options))
+  //   // For each chord, generate a sequence of questions appropriate for the given chord
+  //   // TODO: Generate questions
+  // }
+
+  // Fake a chord:
+  let chord = randomChordContext(options)
+
+  chord.questions = [
+     {
+        "type": "Names",
+        "questionText": "Name the letter positions from lowest to highest.",
+        "answers": [
+           "G",
+           "B",
+           "D",
+           "F"
+        ],
+        "ordered": true,
+        "choices": [
+           {
+              "choice": "A",
+              "key": "a"
+           },
+           {
+              "choice": "B",
+              "key": "b"
+           },
+           {
+              "choice": "C",
+              "key": "c"
+           },
+           {
+              "choice": "D",
+              "key": "d"
+           },
+           {
+              "choice": "E",
+              "key": "e"
+           },
+           {
+              "choice": "F",
+              "key": "f"
+           },
+           {
+              "choice": "G",
+              "key": "g"
+           }
+        ]
+     }
+  ]
+  let chords = [chord]
+
+  return chords
+
   // TODO: Add keyStrokes
   // return addKeystrokes(chords)
 
@@ -266,7 +334,7 @@ export default function(numQs, options) {
  *                  clef, keySignature, chordType, inversion, notes
  *                }
  */
-export function randomChord(options) {
+export function randomChordContext(options) {
   // Choose a random `ChordType` from the constraints provided by the user
   const chordType = chooseChordType(chordTypesOption(options.chordTypes))
   // Choose a random `ChordStructure` belonging to the chosen `ChordType` family
@@ -301,6 +369,8 @@ export function randomChord(options) {
   const result = {
     clef: clef,
     keySignature: vexFlowKeySignature,
+    chordDescription,
+    romanNumeralContext,
     notes: staffAdjustedNotes
   }
   // All done!

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -33,10 +33,6 @@ const RootOption = {
 export function questions(chordContext) {
 
   const rootLetter = chordContext.chordDescription.root.letter
-
-  console.log("root: " + JSON.stringify(chordContext.chordDescription.root))
-  console.log("root letter: " + rootLetter)
-
   const rootAccidental = chordContext.chordDescription.root.accidental
   const inversion = chordContext.chordDescription.inversion
   const degree = chordContext.romanNumeralContext.degree
@@ -126,9 +122,6 @@ export function questions(chordContext) {
       "choices": romanInversionOptions
     }
   ]
-
-  console.log("root answer: " + (rootLetter + rootAccidental))
-  console.log("all notes: " + JSON.stringify(chordContext.notes))
 
   // TODO:
   // for note in template: 
@@ -241,7 +234,6 @@ export function randomChordContext(options) {
   const keySignature = chooseKeySignature()
   // Choose a random roman numeral context
   const romanNumeralContext = randomRomanNumeralContext(chordStructure)
-  console.log("roman numeral context: " + JSON.stringify(romanNumeralContext))
   // Choose a random clef
   const clef = Clef.randomElement()
   // Construct non—octave-positioned description of a chord, in the form:
@@ -260,8 +252,6 @@ export function randomChordContext(options) {
   // FIXME: Codify the relationship between "Shapes" key signatures, Common Western Notation key signatures,
   //        and Vexflow key signatures.
   const vexFlowKeySignature = keySignatures[keySignature].vexSig
-    
-  console.log("key signature: " + JSON.stringify(vexFlowKeySignature))
   // Bundle up all of the information useful to graphically represent the notes on the screen.
   // TODO: Consider bundling up all of the informational artifacts we have created along the way, e.g., 
   //       `chordDescription`, `romanNumeralContext`, etc.
@@ -590,9 +580,6 @@ function chooseRootAccidental(syllable, structure, allowedAccidentals) {
  * @todo                       This algorithm works in quadratic time, but could quite possibly work in constant time.
  */
 export function concretizeRoot(keySignature, modeNote) {
-
-  console.log("concretizeRoot: keySignature: " + keySignature + ", modeNote: " + JSON.stringify(modeNote))
-
   // TODO: ask David-- how do we know accidental at the shapes level of abstraction?
   // TODO: Configure the Shapes object so we don't have iterate through an array of notes each time
   // TODO: Use this function to generate every note not just roots? If so, rename to something like concretizeNote.
@@ -601,20 +588,14 @@ export function concretizeRoot(keySignature, modeNote) {
     if (Shapes[keySignature].notes[i].mode === modeNote) {
       const rootAccidental = shape.notes[i].accidental
       const rootSyllable = shape.notes[i].refIP
-
       // Get the offset from the root accidental from `NATURAL`
       const offset = Accidental.offsetFromNatural(rootAccidental)
-
       // FIXME: (James) Implement convenience getter over `LetterName`
       const rootLetter = Object.values(LetterName)[Object.values(IndependentPitchSubset.BOTTOM).indexOf(rootSyllable)]
-
       // FIXME: (James) Implement convenience getter over `IndependentPitch`
       const rootSyllableIndex = Object.values(IndependentPitch).indexOf(rootSyllable)
       const rootIPIndex = (rootSyllableIndex + offset) % 12
       const rootIP = Object.values(IndependentPitch)[rootIPIndex]
-
-      console.log("result: letter: " + rootLetter + rootAccidental)
-
       return {
         independentPitch: rootIP,
         accidental: rootAccidental,
@@ -839,7 +820,7 @@ export function randomRomanNumeralContext(chordStructure) {
     case ChordStructure.MINOR:
       switch (mode) {
         case Mode.MAJOR: {
-          const modeNote = [Mode.DORIAN, Mode.PHRYIGIAN, Mode.MINOR].randomElement()
+          const modeNote = [Mode.DORIAN, Mode.PHRYGIAN, Mode.MINOR].randomElement()
           const scaleDegree = degree(mode, modeNote)
           return {
             mode: mode,
@@ -916,7 +897,7 @@ export function randomRomanNumeralContext(chordStructure) {
         }
       }
     case ChordStructure.MAJOR_SEVENTH: {
-      const modeNote = [Mode.MAJOR,Mode.LYDIAN].randomElement()
+      const modeNote = [Mode.MAJOR, Mode.LYDIAN].randomElement()
       const scaleDegree = degree(mode, modeNote)
       return {
         mode: mode,

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -801,12 +801,15 @@ export function randomRomanNumeralContext(chordStructure) {
 
   // FIXME: Codify "Major" and "minor" here!  
   const modeLabel = chordStructure.possibleModeEnvironments.randomElement()
+
   let mode
   switch (modeLabel) {
     case "Major":
       mode = Mode.MAJOR
+      break
     case "minor":
       mode = Mode.MINOR
+      break
   }
 
   switch (chordStructure) {

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -45,10 +45,9 @@ export function questions(chordContext) {
   // FIXME: Infer `inversionQuality` somehow?
   const inversionQuality = "???"
 
+  // TODO: Wrap up in own function
   let romanInversionOptions
-
   // [roman + inversionQuality + " " + inversion]
-
   if (chordType === 'triad') {
     romanInversionOptions = [
       roman + inversionQuality,

--- a/src/generator/questionGenerator.js
+++ b/src/generator/questionGenerator.js
@@ -86,7 +86,6 @@ if(chordType === 'seventh'){
   ]
 }
 
-
 // aggregate options for chord quality question
 let qualityOptions = []
 Object.keys(template).map(type => {qualityOptions.push(rootLetter + rootAccidental + type)})

--- a/src/tests/randomChord.test.js
+++ b/src/tests/randomChord.test.js
@@ -164,3 +164,10 @@ test('randomChordContext does not blow up', () => {
   let chord = randomChordContext(options)
 })
 
+test('randomRomanNumeralContext returns a valid mode note', () => {
+  const chordStructure = ChordStructure.MINOR
+  for (var i = 0; i < 100; i++) {
+    const romanNumeralContext = randomRomanNumeralContext(chordStructure)
+    expect(romanNumeralContext.modeNote).toBeDefined()
+  }
+})

--- a/src/tests/randomChord.test.js
+++ b/src/tests/randomChord.test.js
@@ -1,5 +1,5 @@
 import { 
-  randomChord, 
+  randomChordContext, 
   chooseChordType,
   chooseChordStructure, 
   chooseInversion,
@@ -156,11 +156,11 @@ test('concretizeRoot f natural in d', () => {
   expect(result).toStrictEqual(expected)
 })
 
-test('randomChord does not blow up', () => {
+test('randomChordContext does not blow up', () => {
   const options = {
     chordTypes: { triads: true, sevenths: true },
     roots: { common: true, any: false }
   }
-  let chord = randomChord(options)
+  let chord = randomChordContext(options)
 })
 


### PR DESCRIPTION
In the last PR (#48), we add the idea of a chord context, which bundles all of the abstract knowledge about the chord that we have generated (e.g., `chordDescription`, `romanNumeralContext`, etc.)

This PR generates questions from the chord context type.

There is a show-stopping bug or two regarding an ambiguity or misunderstanding or perhaps an `undefined` floating around somewhere which is corrupting the "root" of the chord. This will be addressed in a follow-up PR.