### PR TITLE
Filter out accidentals when inherent in the key signature

### DIFF
--- a/src/generator/Question.js
+++ b/src/generator/Question.js
@@ -18,22 +18,14 @@ export const Question = {
     }
   },
   root: function(chordContext) {
-    // FIXME: Filter out accidentals if they are inherent in the key signature.
     const rootLetter = chordContext.chordDescription.root.letter
     const rootAccidental = chordContext.chordDescription.root.accidental
-
-    console.log("key signature: " + JSON.stringify(chordContext.keySignature))
-
     const shouldFilterOutAccidental = accidentalForLetterNameIsInKeySignature(
       rootLetter,
       rootAccidental,
       chordContext.shape
     )
-
-    const rootAccidentalDisplay = shouldFilterOutAccidental
-      ? ""
-      : chordContext.chordDescription.root.accidental
-
+    const rootAccidentalDisplay = shouldFilterOutAccidental ? "" : rootAccidental
     return {
       "type": "Roots",
       "questionText": "What's the root note?",

--- a/src/generator/Question.js
+++ b/src/generator/Question.js
@@ -17,6 +17,7 @@ export const Question = {
     }
   },
   root: function(chordContext) {
+    // FIXME: Filter out accidentals if they are inherent in the key signature.
     const rootLetter = chordContext.chordDescription.root.letter
     const rootAccidental = chordContext.chordDescription.root.accidental
     return {

--- a/src/generator/Question.js
+++ b/src/generator/Question.js
@@ -30,7 +30,6 @@ export const Question = {
       "type": "Roots",
       "questionText": "What's the root note?",
       "answers": [rootLetter + rootAccidentalDisplay],
-      // FIXME: Currently not filtering out naturals
       "choices": chordContext.notes.map(note => note.letter + note.accidental)
     }
   },

--- a/src/generator/Question.js
+++ b/src/generator/Question.js
@@ -1,5 +1,6 @@
 import { ChordType } from './ChordType'
 import { ChordStructure, chordStructures } from './ChordStructure'
+import { accidentalForLetterNameIsInKeySignature } from './chordGenerator'
 
 /**
  * `Question` is a collection of functions which each take a `chordContext`, and return
@@ -20,10 +21,23 @@ export const Question = {
     // FIXME: Filter out accidentals if they are inherent in the key signature.
     const rootLetter = chordContext.chordDescription.root.letter
     const rootAccidental = chordContext.chordDescription.root.accidental
+
+    console.log("key signature: " + JSON.stringify(chordContext.keySignature))
+
+    const shouldFilterOutAccidental = accidentalForLetterNameIsInKeySignature(
+      rootLetter,
+      rootAccidental,
+      chordContext.shape
+    )
+
+    const rootAccidentalDisplay = shouldFilterOutAccidental
+      ? ""
+      : chordContext.chordDescription.root.accidental
+
     return {
       "type": "Roots",
       "questionText": "What's the root note?",
-      "answers": [rootLetter + rootAccidental],
+      "answers": [rootLetter + rootAccidentalDisplay],
       // FIXME: Currently not filtering out naturals
       "choices": chordContext.notes.map(note => note.letter + note.accidental)
     }

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -132,6 +132,7 @@ export function randomChordContext(options) {
   //       `chordDescription`, `romanNumeralContext`, etc.
   const result = {
     clef: clef,
+    shape: keySignature,
     keySignature: vexFlowKeySignature,
     modeLabel: modeLabel,
     chordType: chordType,
@@ -248,6 +249,7 @@ export function partiallyConcretizeChord(chordDescription, keySignature) {
  * @return Boolean      `true` if the given `letterName` is inherent in the given
  *                      `keySignature` is associated with the given `accidental`.
  *                      Otherwise, `false`.
+ * @todo                Move to `Accidental` or somewhere similarly low-level
  */
 export function accidentalForLetterNameIsInKeySignature(letterName, accidental, keySignature) {
   const noteInKeySignature = Shapes[keySignature].notes.find(note =>

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -219,11 +219,16 @@ export function partiallyConcretizeChord(chordDescription, keySignature) {
     if (notePosition < prevLetterNamePosition) { octaveDisplacement += 1 }
     prevLetterNamePosition = notePosition
 
-    // Create the note with all of our nice new data
-    // FIXME: Filter out accidentals if they are inherent in the key signature!
+    const accid = accidental(noteIP, syllable)
+    const shouldFilterOutAccidental = accidentalForLetterNameIsInKeySignature(
+      noteLetter,
+      accid,
+      keySignature
+    )
+
     const note = {
       letter: noteLetter,
-      accidental: accidental(noteIP, syllable),
+      accidental: shouldFilterOutAccidental ? "" : accidental(noteIP, syllable),
       octave: octaveDisplacement
     }
 

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -220,6 +220,7 @@ export function partiallyConcretizeChord(chordDescription, keySignature) {
     prevLetterNamePosition = notePosition
 
     // Create the note with all of our nice new data
+    // FIXME: Filter out accidentals if they are inherent in the key signature!
     const note = {
       letter: noteLetter,
       accidental: accidental(noteIP, syllable),
@@ -233,6 +234,43 @@ export function partiallyConcretizeChord(chordDescription, keySignature) {
   return notes
 }
 
+/**
+ * accidentalForLetterNameIsInKeySignature - description
+ *
+ * @param  LetterName   letterName
+ * @param  Accidental   accidental
+ * @param  KeySignature keySignature
+ * @return Boolean      `true` if the given `letterName` is inherent in the given
+ *                      `keySignature` is associated with the given `accidental`.
+ *                      Otherwise, `false`.
+ */
+export function accidentalForLetterNameIsInKeySignature(letterName, accidental, keySignature) {
+  const noteInKeySignature = Shapes[keySignature].notes.find(note =>
+    note.refIP == letterNameToRefIP(letterName)
+  )
+  return accidental == noteInKeySignature.accidental
+}
+
+function letterNameToRefIP(letter) {
+  switch (letter) {
+    case LetterName.C:
+      return IndependentPitch.DO
+    case LetterName.D:
+      return IndependentPitch.RE
+    case LetterName.E:
+      return IndependentPitch.MI
+    case LetterName.F:
+      return IndependentPitch.FA
+    case LetterName.G:
+      return IndependentPitch.SO
+    case LetterName.A:
+      return IndependentPitch.LA
+    case LetterName.B:
+      return IndependentPitch.TI
+    default:
+      throw 'invalid letter name'
+  }
+}
 
 function chordComponentSyllable(translatedNoteIPIndex, chordDescription) {
 

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -36,30 +36,6 @@ export function questions(chordContext) {
   // Retrieve all of the question for the `chordType` of the given `chordContext`,
   // and apply them to the given `chordContext`.
   return questionsForChordType(chordContext.chordType).map(question => question(chordContext))
-
-  // TODO:
-  // for note in template:
-    // // push notes into questions before adjusting accidentals for key sig
-    // chord.questions[0].answers.push(noteLetter);
-
-
-    // // FIXME: This should be its own function
-    // // only show natural in question choices if it's an alteration from the key sig
-    // if(accidental != '♮'){
-    //   chord.questions[1].choices.push(noteLetter+accidental);
-    // }
-    // else if ((accidental === '♮') && (keySignatures[keySignature].notes[keySignatures[keySignature].notes.findIndex(function(syllable){return syllable.refIP === noteSyllable})].accidental != '♮')){
-    //   chord.questions[1].choices.push(noteLetter+'♮');
-    // }
-    // else {
-    //   chord.questions[1].choices.push(noteLetter);
-    // }
-
-    // // adjust accidentals for key sig (if an accidental is in the key sig, don't add it to the note)
-    // if(accidental === keySignatures[keySignature].notes[keySignatures[keySignature].notes.findIndex(function(syllable){return syllable.refIP === noteSyllable})].accidental){
-    //   accidental = "";
-    // }
-  // }
 }
 
 /**

--- a/src/tests/randomChord.test.js
+++ b/src/tests/randomChord.test.js
@@ -7,7 +7,8 @@ import {
   randomRomanNumeralContext,
   makeChordDescription,
   partiallyConcretizeChord,
-  concretizeRoot
+  concretizeRoot,
+  accidentalForLetterNameIsInKeySignature
 } from '../generator/chordGenerator'
 import { IndependentPitch } from '../generator/IP'
 import { Accidental } from '../generator/Accidental'
@@ -147,4 +148,14 @@ test('randomRomanNumeralContext returns a valid mode note and degree', () => {
     expect(romanNumeralContext.modeNote).toBeDefined()
     expect(romanNumeralContext.degree).toBeDefined()
   }
+})
+
+test('c natural is in key signature with no sharps nor flats', () => {
+  expect(accidentalForLetterNameIsInKeySignature(LetterName.C, Accidental.NATURAL, "B"))
+    .toBeTruthy()
+})
+
+test('c sharp is not in key signature with no sharps nor flats', () => {
+  expect(accidentalForLetterNameIsInKeySignature(LetterName.C, Accidental.SHARP, "B"))
+    .toBeFalsy()
 })


### PR DESCRIPTION
This PR filters out accidentals from staff display and answers when they are inherent in the given key signature.