### PR TITLE
Add Travis CI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 ## a training app for music 51
+
+[![Build Status](https://travis-ci.com/1aurend/music51.svg?branch=master)](https://travis-ci.org/1aurend/music51)


### PR DESCRIPTION
This PR adds a badge for Travis CI status. This will give us an at-a-glance view of the testing success (or failure) of our `master` branch.

I would say it would be wise to keep `master` always green.