### PR TITLE
Fix augemented sixth spelling

### DIFF
--- a/src/generator/ChordStructure.js
+++ b/src/generator/ChordStructure.js
@@ -176,12 +176,12 @@ export const ChordStructure = {
   },
   GERMAN_AUGMENTED_SIXTH: {
     displayName: "Ger+6",
-    modeConstructor: Mode.PHRYGIAN,
+    modeConstructor: Mode.AUGMENTED_SIXTH,
     structure: [
-      IndependentPitch.PE, // Ab (in the bass)
-      IndependentPitch.DO, // C
-      IndependentPitch.NA, // EB
-      IndependentPitch.VE // F#
+      IndependentPitch.DO, // C (in the bass)
+      IndependentPitch.MI, // E
+      IndependentPitch.SO, // Ab
+      IndependentPitch.KE // F#
     ],
     possibleRootOffsets: [8],
     commonRootOffsets: {

--- a/src/generator/ChordStructure.js
+++ b/src/generator/ChordStructure.js
@@ -161,12 +161,12 @@ export const ChordStructure = {
   },
   FRENCH_AUGMENTED_SIXTH: {
     displayName: "Fr+6",
-    modeConstructor: Mode.PHRYGIAN,
+    modeConstructor: Mode.AUGMENTED_SIXTH,
     structure: [
-      IndependentPitch.PE, // Ab (in the bass)
-      IndependentPitch.DO, // C
-      IndependentPitch.RE, // D
-      IndependentPitch.VE // F#
+      IndependentPitch.DO, // C (in the bass)
+      IndependentPitch.MI, // E
+      IndependentPitch.VE, // G
+      IndependentPitch.KE // A#
     ],
     possibleRootOffsets: [8],
     commonRootOffsets: {

--- a/src/generator/ChordStructure.js
+++ b/src/generator/ChordStructure.js
@@ -147,11 +147,11 @@ export const ChordStructure = {
   },
   ITALIAN_AUGMENTED_SIXTH: {
     displayName: "It+6",
-    modeConstructor: Mode.PHRYGIAN, // TODO: consider an intervalic approach rather than modeConstructor. See commit comments.
+    modeConstructor: Mode.AUGMENTED_SIXTH, // TODO: consider an intervalic approach rather than modeConstructor. See commit comments.
     structure: [
-      IndependentPitch.PE, // Ab (in the bass)
-      IndependentPitch.DO, // C
-      IndependentPitch.VE // F#
+      IndependentPitch.DO, // C (in the bass)
+      IndependentPitch.MI, // E
+      IndependentPitch.KE // A#
     ],
     possibleRootOffsets: [8],
     commonRootOffsets: {

--- a/src/generator/Mode.js
+++ b/src/generator/Mode.js
@@ -687,69 +687,70 @@ export function noteIdentities(mode) {
           "incidental": 1
         }
       ]
+    // FIXME: (James) This is a hack to make +6 chords to be spelled correctly
     case Mode.AUGMENTED_SIXTH:
-    return [
-      {
-        "tensionMod7": 1,
-        "quality": 0,
-        "incidental": 0
-      },
-      {
-        // "tensionMod7": 2,
-        // "quality": -1,
-        // "incidental": -1
-      },
-      {
-        // "tensionMod7": 2,
-        // "quality": 1,
-        // "incidental": 0
-      },
-      {
-        // "tensionMod7": 2,
-        // "quality": 2,
-        // "incidental": 1
-      },
-      {
-        "tensionMod7": 3,
-        "quality": 1,
-        "incidental": 0
-      },
-      {
-        // "tensionMod7": 4,
-        // "quality": 0,
-        // "incidental": -1
-      },
-      {
-        // "tensionMod7": 4,
-        // "quality": 1,
-        // "incidental": 0
-      },
-      {
-        // "tensionMod7": 5,
-        // "quality": 0,
-        // "incidental": -1
-      },
-      {
-        // "tensionMod7": 5,
-        // "quality": 1,
-        // "incidental": 0
-      },
-      {
-        // "tensionMod7": 6,
-        // "quality": -2,
-        // "incidental": 1
-      },
-      {
-        "tensionMod7": 6,
-        "quality": 1,
-        "incidental": 1
-      },
-      {
-        // "tensionMod7": 7,
-        // "quality": 1,
-        // "incidental": 1
-      }
-    ]
+      return [
+        {
+          "tensionMod7": 1,
+          "quality": 0,
+          "incidental": 0
+        },
+        {
+          // "tensionMod7": 2,
+          // "quality": -1,
+          // "incidental": -1
+        },
+        {
+          // "tensionMod7": 2,
+          // "quality": 1,
+          // "incidental": 0
+        },
+        {
+          // "tensionMod7": 2,
+          // "quality": 2,
+          // "incidental": 1
+        },
+        {
+          "tensionMod7": 3,
+          "quality": 1,
+          "incidental": 0
+        },
+        {
+          // "tensionMod7": 4,
+          // "quality": 0,
+          // "incidental": -1
+        },
+        {
+          "tensionMod7": 4,
+          "quality": 1,
+          "incidental": 0
+        },
+        {
+          // "tensionMod7": 5,
+          // "quality": 0,
+          // "incidental": -1
+        },
+        {
+          // "tensionMod7": 5,
+          // "quality": 1,
+          // "incidental": 0
+        },
+        {
+          // "tensionMod7": 6,
+          // "quality": -2,
+          // "incidental": 1
+        },
+        {
+          "tensionMod7": 6,
+          "quality": 1,
+          "incidental": 1
+        },
+        {
+          // "tensionMod7": 7,
+          // "quality": 1,
+          // "incidental": 1
+        }
+      ]
     default:
       throw "Unsupported Mode: " + JSON.stringify(mode)
   }

--- a/src/generator/Mode.js
+++ b/src/generator/Mode.js
@@ -696,19 +696,13 @@ export function noteIdentities(mode) {
           "incidental": 0
         },
         {
-          // "tensionMod7": 2,
-          // "quality": -1,
-          // "incidental": -1
+          // nope
         },
         {
-          // "tensionMod7": 2,
-          // "quality": 1,
-          // "incidental": 0
+          // nope
         },
         {
-          // "tensionMod7": 2,
-          // "quality": 2,
-          // "incidental": 1
+          // nope
         },
         {
           "tensionMod7": 3,
@@ -716,9 +710,7 @@ export function noteIdentities(mode) {
           "incidental": 0
         },
         {
-          // "tensionMod7": 4,
-          // "quality": 0,
-          // "incidental": -1
+          // nope
         },
         {
           "tensionMod7": 4,
@@ -726,19 +718,15 @@ export function noteIdentities(mode) {
           "incidental": 0
         },
         {
-          // "tensionMod7": 5,
-          // "quality": 0,
-          // "incidental": -1
+          "tensionMod7": 5,
+          "quality": 0,
+          "incidental": -1
         },
         {
-          // "tensionMod7": 5,
-          // "quality": 1,
-          // "incidental": 0
+          // nope
         },
         {
-          // "tensionMod7": 6,
-          // "quality": -2,
-          // "incidental": 1
+          // nope
         },
         {
           "tensionMod7": 6,
@@ -746,9 +734,7 @@ export function noteIdentities(mode) {
           "incidental": 1
         },
         {
-          // "tensionMod7": 7,
-          // "quality": 1,
-          // "incidental": 1
+          // nope
         }
       ]
     default:

--- a/src/generator/Mode.js
+++ b/src/generator/Mode.js
@@ -16,6 +16,8 @@ export const Mode = { // TODO: these should be called modeConstructor to differe
   DOMINANT_ALTERED: "DA",
   DIMINISHED: 'dim',
   AUGMENTED_DOMINANT: 'AD',
+  // FIXME: This is added by James as a hack to spell augmented sixth chords properly
+  AUGMENTED_SIXTH: 'A6'
 }
 
 export const ModeSubset = {
@@ -685,6 +687,69 @@ export function noteIdentities(mode) {
           "incidental": 1
         }
       ]
+    case Mode.AUGMENTED_SIXTH:
+    return [
+      {
+        "tensionMod7": 1,
+        "quality": 0,
+        "incidental": 0
+      },
+      {
+        // "tensionMod7": 2,
+        // "quality": -1,
+        // "incidental": -1
+      },
+      {
+        // "tensionMod7": 2,
+        // "quality": 1,
+        // "incidental": 0
+      },
+      {
+        // "tensionMod7": 2,
+        // "quality": 2,
+        // "incidental": 1
+      },
+      {
+        "tensionMod7": 3,
+        "quality": 1,
+        "incidental": 0
+      },
+      {
+        // "tensionMod7": 4,
+        // "quality": 0,
+        // "incidental": -1
+      },
+      {
+        // "tensionMod7": 4,
+        // "quality": 1,
+        // "incidental": 0
+      },
+      {
+        // "tensionMod7": 5,
+        // "quality": 0,
+        // "incidental": -1
+      },
+      {
+        // "tensionMod7": 5,
+        // "quality": 1,
+        // "incidental": 0
+      },
+      {
+        // "tensionMod7": 6,
+        // "quality": -2,
+        // "incidental": 1
+      },
+      {
+        "tensionMod7": 6,
+        "quality": 1,
+        "incidental": 1
+      },
+      {
+        // "tensionMod7": 7,
+        // "quality": 1,
+        // "incidental": 1
+      }
+    ]
     default:
       throw "Unsupported Mode: " + JSON.stringify(mode)
   }

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -140,6 +140,7 @@ export function makeChordDescription(
     keySignature,
     romanNumeralContext
   )
+  console.log("concretized root: " + concretizedRoot.letter + concretizedRoot.accidental)
   return {
     root: concretizedRoot,
     structure: chordStructure,
@@ -589,11 +590,11 @@ function inversions(chordStructure) {
       return ["","65","43","42"]
     // Unique cases
     case ChordStructure.NEAPOLITAN_SIXTH:
-      return ["", "6"]
+      return ["", "63"]
     case ChordStructure.ITALIAN_AUGMENTED_SIXTH:
     case ChordStructure.FRENCH_AUGMENTED_SIXTH:
     case ChordStructure.GERMAN_AUGMENTED_SIXTH:
-      return ["6"]
+      return [""]
     default:
       throw "Invalid chord structure: " + JSON.stringify(chordStructure)
   }

--- a/src/generator/chordGenerator.js
+++ b/src/generator/chordGenerator.js
@@ -140,7 +140,6 @@ export function makeChordDescription(
     keySignature,
     romanNumeralContext
   )
-  console.log("concretized root: " + concretizedRoot.letter + concretizedRoot.accidental)
   return {
     root: concretizedRoot,
     structure: chordStructure,

--- a/src/tests/randomChord.test.js
+++ b/src/tests/randomChord.test.js
@@ -203,7 +203,7 @@ test('N6 in C Major is spelled correctly', () => {
     rootOffset: 1,
     degree: 2,
     romanNumeral: 'N6',
-    incidental: -1
+    incidental: 0
   }
   const chordDescription = makeChordDescription(
     chordStructure,
@@ -226,6 +226,44 @@ test('N6 in C Major is spelled correctly', () => {
     {
       letter: LetterName.D,
       accidental: Accidental.FLAT,
+      octave: 1
+    }
+  ]
+  expect(partiallyConcretized).toStrictEqual(expected)
+})
+
+test('It+6 in C Major is spelled correctly', () => {
+  const chordStructure = ChordStructure.ITALIAN_AUGMENTED_SIXTH
+  const inversion = ""
+  const keySignature = 'B' // C
+  const romanNumeralContext = {
+    mode: Mode.MAJOR,
+    rootOffset: 8,
+    degree: 6,
+    romanNumeral: 'It+6',
+    incidental: -1
+  }
+  const chordDescription = makeChordDescription(
+    chordStructure,
+    inversion,
+    keySignature,
+    romanNumeralContext
+  )
+  const partiallyConcretized = partiallyConcretizeChord(chordDescription, keySignature)
+  const expected = [
+    {
+      letter: LetterName.A,
+      accidental: Accidental.FLAT,
+      octave: 0
+    },
+    {
+      letter: LetterName.C,
+      accidental: "",
+      octave: 1
+    },
+    {
+      letter: LetterName.F,
+      accidental: Accidental.SHARP,
       octave: 1
     }
   ]

--- a/src/tests/randomChord.test.js
+++ b/src/tests/randomChord.test.js
@@ -313,6 +313,49 @@ test('Fr+6 in C Major is spelled correctly', () => {
   expect(partiallyConcretized).toStrictEqual(expected)
 })
 
+test('Gr+6 in C Major is spelled correctly', () => {
+  const chordStructure = ChordStructure.GERMAN_AUGMENTED_SIXTH
+  const inversion = ""
+  const keySignature = 'B' // C
+  const romanNumeralContext = {
+    mode: Mode.MAJOR,
+    rootOffset: 8,
+    degree: 6,
+    romanNumeral: 'Gr+6',
+    incidental: -1
+  }
+  const chordDescription = makeChordDescription(
+    chordStructure,
+    inversion,
+    keySignature,
+    romanNumeralContext
+  )
+  const partiallyConcretized = partiallyConcretizeChord(chordDescription, keySignature)
+  const expected = [
+    {
+      letter: LetterName.A,
+      accidental: Accidental.FLAT,
+      octave: 0
+    },
+    {
+      letter: LetterName.C,
+      accidental: "",
+      octave: 1
+    },
+    {
+      letter: LetterName.E,
+      accidental: Accidental.FLAT,
+      octave: 1
+    },
+    {
+      letter: LetterName.F,
+      accidental: Accidental.SHARP,
+      octave: 1
+    }
+  ]
+  expect(partiallyConcretized).toStrictEqual(expected)
+})
+
 
 test('randomRomanNumeralContext for Ger+6 in C Major is valid', () => {
   const romanNumeralContext = randomRomanNumeralContext(ChordStructure.GERMAN_AUGMENTED_SIXTH, "Major")

--- a/src/tests/randomChord.test.js
+++ b/src/tests/randomChord.test.js
@@ -270,6 +270,50 @@ test('It+6 in C Major is spelled correctly', () => {
   expect(partiallyConcretized).toStrictEqual(expected)
 })
 
+test('Fr+6 in C Major is spelled correctly', () => {
+  const chordStructure = ChordStructure.FRENCH_AUGMENTED_SIXTH
+  const inversion = ""
+  const keySignature = 'B' // C
+  const romanNumeralContext = {
+    mode: Mode.MAJOR,
+    rootOffset: 8,
+    degree: 6,
+    romanNumeral: 'Fr+6',
+    incidental: -1
+  }
+  const chordDescription = makeChordDescription(
+    chordStructure,
+    inversion,
+    keySignature,
+    romanNumeralContext
+  )
+  const partiallyConcretized = partiallyConcretizeChord(chordDescription, keySignature)
+  const expected = [
+    {
+      letter: LetterName.A,
+      accidental: Accidental.FLAT,
+      octave: 0
+    },
+    {
+      letter: LetterName.C,
+      accidental: "",
+      octave: 1
+    },
+    {
+      letter: LetterName.D,
+      accidental: "",
+      octave: 1
+    },
+    {
+      letter: LetterName.F,
+      accidental: Accidental.SHARP,
+      octave: 1
+    }
+  ]
+  expect(partiallyConcretized).toStrictEqual(expected)
+})
+
+
 test('randomRomanNumeralContext for Ger+6 in C Major is valid', () => {
   const romanNumeralContext = randomRomanNumeralContext(ChordStructure.GERMAN_AUGMENTED_SIXTH, "Major")
   expect(romanNumeralContext).toBeDefined()


### PR DESCRIPTION
This PR adds an egregious hack to make augmented sixth chords get spelled properly.

Augmented sixth chords bend our current strategy a little bit. It will be worthwhile investigating building these up intervallically.