### PR TITLE
Fix mode mixture and applied chord spelling in flat keys

### DIFF
--- a/src/generator/Question.js
+++ b/src/generator/Question.js
@@ -212,7 +212,7 @@ export const Question = {
             choices = ["I", "ii", "iii", "IV", "V", "vi", "viio"]
             break
           case "minor":
-            choices = ["i", "iio", "III", "iv", "V", "VI", "viio", "i"]
+            choices = ["i", "iio", "III", "iv", "V", "VI", "viio"]
             break
         }
         break

--- a/src/generator/keystrokes.js
+++ b/src/generator/keystrokes.js
@@ -270,11 +270,34 @@ export default function addKeystrokes(chords) {
               choicesWithKeys.push(withKeystroke)
               break
             case questionTypes.WHAT_FOLLOWS:
+              // // FIXME: (James) This is a hack which should be handled more
+              // //        elegantly.
+              // if (chord.chordType === ChordType.CHROMATIC_VARIATION) {
+              //   let chromaticKey
+              //   switch (choice) {
+              //     case 'I':
+              //     case 'i':
+              //     case 'V':
+              //       chromaticKey = choice
+              //       break
+              //     case 'Cad64':
+              //       chromaticKey = 'c'
+              //       break
+              //     default:
+              //       throw "Unsupported choice for Role question: " + choice
+              //   }
+              //   withKeystroke = { choice: choice, key: chromaticKey }
+              //   choicesWithKeys.push(withKeystroke)
+              //   break
+              // }
+
               let key
               switch (choice) {
                 case 'I':
+                  key = 'I'
+                  break
                 case 'i':
-                  key = '1'
+                  key = 'i'
                   break
                 case 'ii':
                 case 'iio':
@@ -290,7 +313,7 @@ export default function addKeystrokes(chords) {
                   break
                 case 'V':
                 case 'v':
-                  key = '5'
+                  key = 'V'
                   break
                 case 'VI':
                 case 'vi':

--- a/src/tests/randomChord.test.js
+++ b/src/tests/randomChord.test.js
@@ -425,7 +425,7 @@ test('bVII in B flat Major is spelled correctly', () => {
     },
     {
       letter: LetterName.E,
-      accidental: Accidental.FLAT,
+      accidental: "",
       octave: 1
     }
   ]

--- a/src/tests/randomChord.test.js
+++ b/src/tests/randomChord.test.js
@@ -356,6 +356,81 @@ test('Gr+6 in C Major is spelled correctly', () => {
   expect(partiallyConcretized).toStrictEqual(expected)
 })
 
+test('bVII in C Major is spelled correctly', () => {
+  const chordStructure = ChordStructure.FLAT_SEVEN_MAJOR_TRIAD
+  const inversion = ""
+  const keySignature = 'B' // C
+  const romanNumeralContext = {
+    mode: Mode.MAJOR,
+    rootOffset: 10,
+    degree: 7,
+    romanNumeral: 'bVII',
+    incidental: -1
+  }
+  const chordDescription = makeChordDescription(
+    chordStructure,
+    inversion,
+    keySignature,
+    romanNumeralContext
+  )
+  const partiallyConcretized = partiallyConcretizeChord(chordDescription, keySignature)
+  const expected = [
+    {
+      letter: LetterName.B,
+      accidental: Accidental.FLAT,
+      octave: 0
+    },
+    {
+      letter: LetterName.D,
+      accidental: "",
+      octave: 1
+    },
+    {
+      letter: LetterName.F,
+      accidental: "",
+      octave: 1
+    }
+  ]
+  expect(partiallyConcretized).toStrictEqual(expected)
+})
+
+test('bVII in B flat Major is spelled correctly', () => {
+  const chordStructure = ChordStructure.FLAT_SEVEN_MAJOR_TRIAD
+  const inversion = ""
+  const keySignature = 'R2' // C
+  const romanNumeralContext = {
+    mode: Mode.MAJOR,
+    rootOffset: 10,
+    degree: 7,
+    romanNumeral: 'bVII',
+    incidental: -1
+  }
+  const chordDescription = makeChordDescription(
+    chordStructure,
+    inversion,
+    keySignature,
+    romanNumeralContext
+  )
+  const partiallyConcretized = partiallyConcretizeChord(chordDescription, keySignature)
+  const expected = [
+    {
+      letter: LetterName.A,
+      accidental: Accidental.FLAT,
+      octave: 0
+    },
+    {
+      letter: LetterName.C,
+      accidental: "",
+      octave: 1
+    },
+    {
+      letter: LetterName.E,
+      accidental: Accidental.FLAT,
+      octave: 1
+    }
+  ]
+  expect(partiallyConcretized).toStrictEqual(expected)
+})
 
 test('randomRomanNumeralContext for Ger+6 in C Major is valid', () => {
   const romanNumeralContext = randomRomanNumeralContext(ChordStructure.GERMAN_AUGMENTED_SIXTH, "Major")


### PR DESCRIPTION
For some reason, some mode mixture and applied chords are being spelled strangely (in flat keys only).

This PR is currently poking into this and will eventually address this.

This is currently showstopping, as there is a discrepancy between what the real "answer" is, and the way that it is spelled. Thus, if you run into this as a user, there is no way to proceed through this.