### PR TITLE
Dev mode styling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,7 +9,7 @@
     <link href="https://fonts.googleapis.com/css?family=Overpass|Overpass+Mono|Press+Start+2P&display=swap&subset=latin-ext" rel="stylesheet">
     <title>Chord Crusher</title>
   </head>
-  <body style="background-color:#082742;">
+  <body style="background-color:#353637;">
     <div id="root"></div>
   </body>
 </html>

--- a/src/Router.js
+++ b/src/Router.js
@@ -196,6 +196,183 @@ const mockData = {
              ]
           }
     }
+const mockChart = {
+        "chartData": {
+          "domainMaxYAtt": 9,
+          "domainMaxYTime": 67.3,
+          "labelsX": [
+            1,
+            2
+          ],
+          "categoriesIncluded": [
+            "Overall",
+            "Degrees",
+            "Names",
+            "Role",
+            "Quality"
+          ],
+          "categoriesAtt": [
+            "Overall",
+            "Degrees",
+            "Names",
+            "Role"
+          ],
+          "categoriesTime": [
+            "Overall",
+            "Names",
+            "Degrees",
+            "Quality"
+          ],
+          "colorScaleAtt": [
+            "#000000",
+            "#f8c000",
+            "#cc351f",
+            "#3b9b4d"
+          ],
+          "colorScaleTime": [
+            "#000000",
+            "#cc351f",
+            "#f8c000",
+            "#1c4af2"
+          ],
+          "data": {
+            "attempts": {
+              "Overall": [
+                {
+                  "x": 1,
+                  "y": 3,
+                  "symbol": "square",
+                  "size": 5
+                },
+                {
+                  "x": 2,
+                  "y": 2,
+                  "symbol": "square",
+                  "size": 5
+                }
+              ],
+              "Degrees": [
+                {
+                  "x": 1,
+                  "y": 4,
+                  "symbol": "square",
+                  "size": 5
+                },
+                {
+                  "x": 2,
+                  "y": 9,
+                  "symbol": "square",
+                  "size": 5
+                }
+              ],
+              "Names": [
+                {
+                  "x": 1,
+                  "y": 3,
+                  "symbol": "square",
+                  "size": 5
+                },
+                {
+                  "x": 2,
+                  "y": 1,
+                  "symbol": "square",
+                  "size": 5
+                },
+                {
+                  "x": 3,
+                  "y": 7,
+                  "symbol": "square",
+                  "size": 5
+                }
+              ],
+              "Role": [
+                {
+                  "x": 1,
+                  "y": 2,
+                  "symbol": "square",
+                  "size": 5
+                },
+                {
+                  "x": 2,
+                  "y": 6,
+                  "symbol": "square",
+                  "size": 5
+                }
+              ]
+            },
+            "times": {
+              "Overall": [
+                {
+                  "x": 1,
+                  "y": 1.18,
+                  "symbol": "square",
+                  "size": 5
+                },
+                {
+                  "x": 2,
+                  "y": 2.3,
+                  "symbol": "square",
+                  "size": 5
+                }
+              ],
+              "Names": [
+                {
+                  "x": 1,
+                  "y": 2.3,
+                  "symbol": "square",
+                  "size": 5
+                },
+                {
+                  "x": 2,
+                  "y": 1.85,
+                  "symbol": "square",
+                  "size": 5
+                },
+                {
+                  "x": 3,
+                  "y": 67.3,
+                  "symbol": "square",
+                  "size": 5
+                }
+              ],
+              "Degrees": [
+                {
+                  "x": 1,
+                  "y": 4.5,
+                  "symbol": "square",
+                  "size": 5
+                },
+                {
+                  "x": 2,
+                  "y": 6,
+                  "symbol": "square",
+                  "size": 5
+                }
+              ],
+              "Quality": [
+                {
+                  "x": 2,
+                  "y": 0.5,
+                  "symbol": "square",
+                  "size": 5
+                }
+              ]
+            }
+          }
+        },
+        "progressSummary": {
+          "attempts": {
+            "num": 1,
+            "percent": 33,
+            "verb": "decreased"
+          },
+          "times": {
+            "num": 1.12,
+            "percent": 95,
+            "verb": "increased"
+          }
+        }
+}
 
 export default function Router() {
     return (
@@ -220,13 +397,14 @@ export default function Router() {
             currentInput={'a'}
             />} />
         <Route path='/stats' exact render={() => <DevStatLines
-            round={3}
+            round={3} /*change this prop to 1 to see the other look*/
             setShowStats={mock}
             nextRound={mock}
             finished={mock}
+            mockData={mockData}
             />} />
           <Route path='/chart' exact render={() => <DevChartLayout
-              chartData
+              chartData={mockChart}
               round={3}
               finished={mock}
               viewStats={mock}

--- a/src/Router.js
+++ b/src/Router.js
@@ -83,8 +83,119 @@ const sampleChord =
          },
        ]
      }
-
 const sampleRef = {current: sampleChord}
+const mockData = {
+          "Names": {
+             "attempts": [
+                3,
+                1,
+                7
+             ],
+             "times": [
+                2.3,
+                1.85,
+                67.3
+             ]
+          },
+          "Roots": {
+             "attempts": [
+                null,
+                null,
+                null,
+             ],
+             "times": [
+                null,
+                null,
+                null
+             ]
+          },
+          "Degrees": {
+             "attempts": [
+                4,
+                9,
+                2
+             ],
+             "times": [
+                4.5,
+                6,
+                1.2
+             ]
+          },
+          "Role": {
+             "attempts": [
+                2,
+                6,
+                3
+             ],
+             "times": [
+                1.2,
+                1.2,
+                3.4
+             ]
+          },
+          "Numerals": {
+             "attempts": [
+                null,
+                null,
+                null
+             ],
+             "times": [
+                null,
+                null,
+                null
+             ]
+          },
+          "Quality": {
+             "attempts": [
+                null,
+                4,
+                1,
+                5
+             ],
+             "times": [
+                null,
+                0.5,
+                1.2,
+                1.9
+             ]
+          },
+          "Inversions": {
+             "attempts": [
+                2,
+                null,
+                null
+             ],
+             "times": [
+                0.3,
+                null,
+                null
+             ]
+          },
+          "Follows": {
+             "attempts": [
+                null,
+                null,
+                2
+             ],
+             "times": [
+                null,
+                null,
+                3.4
+             ]
+          },
+          "Overall": {
+             "attempts": [
+                3,
+                2,
+                5
+             ],
+             "times": [
+                1.18,
+                2.3,
+                6.4
+             ]
+          }
+    }
 
 export default function Router() {
     return (
@@ -124,6 +235,7 @@ export default function Router() {
         <Route path='/table' exact render={() => <DevResultsTable
             round={3}
             startOver={mock}
+            mockData={mockData}
             />} />
       </BrowserRouter>
     )

--- a/src/Router.js
+++ b/src/Router.js
@@ -3,13 +3,128 @@ import Context from './components/data/Context'
 import { BrowserRouter, Route } from 'react-router-dom'
 import "bootstrap/dist/css/bootstrap.min.css"
 import "shards-ui/dist/css/shards.min.css"
+import DevResultsTable from './components/views/layouts/stylingDevLayouts/DevResultsTable'
+import DevStartScreen from './components/views/layouts/stylingDevLayouts/DevStartScreen'
+import DevQuizQuestion from './components/views/layouts/stylingDevLayouts/DevQuizQuestion'
+import DevStatLines from './components/views/layouts/stylingDevLayouts/DevStatLines'
+import DevChartLayout from './components/views/layouts/stylingDevLayouts/DevChartLayout'
 
 
-//Note: we're not currently doing any routing but may want to later when we have multiple modes/menus
+const mock = () => {
+  alert('some function would run here')
+}
+const sampleChord =
+   {
+      "clef": "treble",
+      "keySignature": "F",
+      "notes": [
+         {
+            "letter": "G",
+            "accidental": "",
+            "octave": 4
+         },
+         {
+            "letter": "B",
+            "accidental": "",
+            "octave": 4
+         },
+         {
+            "letter": "D",
+            "accidental": "",
+            "octave": 5
+         },
+         {
+            "letter": "F",
+            "accidental": "",
+            "octave": 5
+         }
+      ],
+      "questions": [
+         {
+            "type": "Names",
+            "questionText": "Name the letter positions from lowest to highest.",
+            "answers": [
+               "G",
+               "B",
+               "D",
+               "F"
+            ],
+            "ordered": true,
+            "choices": [
+               {
+                  "choice": "A",
+                  "key": "a"
+               },
+               {
+                  "choice": "B",
+                  "key": "b"
+               },
+               {
+                  "choice": "C",
+                  "key": "c"
+               },
+               {
+                  "choice": "D",
+                  "key": "d"
+               },
+               {
+                  "choice": "E",
+                  "key": "e"
+               },
+               {
+                  "choice": "F",
+                  "key": "f"
+               },
+               {
+                  "choice": "G",
+                  "key": "g"
+               }
+            ]
+         },
+       ]
+     }
+
+const sampleRef = {current: sampleChord}
+
 export default function Router() {
     return (
       <BrowserRouter>
         <Route path='/' exact component={Context} />
+        <Route path='/start' exact render={() => <DevStartScreen
+            title={{headline: 'Chord Crusher', mode: '*non-diatonic mode*', subtitle: 'MUSIC 51'}}
+            generateQuiz={mock}
+            numQs={1}
+            onCheck={mock}
+            options={{
+              chordTypes: {triads:true, sevenths:true},
+              roots: {common:true, any:false}
+            }}
+            />} />
+        <Route path='/quiz' exact render={() => <DevQuizQuestion
+            chord={sampleRef}
+            question={sampleChord.questions[0]}
+            colors={[]}
+            handleClick={mock}
+            onKeyPressed={mock}
+            currentInput={'a'}
+            />} />
+        <Route path='/stats' exact render={() => <DevStatLines
+            round={3}
+            setShowStats={mock}
+            nextRound={mock}
+            finished={mock}
+            />} />
+          <Route path='/chart' exact render={() => <DevChartLayout
+              chartData
+              round={3}
+              finished={mock}
+              viewStats={mock}
+              nextRound={mock}
+              />} />
+        <Route path='/table' exact render={() => <DevResultsTable
+            round={3}
+            startOver={mock}
+            />} />
       </BrowserRouter>
     )
   }

--- a/src/components/views/Theme.js
+++ b/src/components/views/Theme.js
@@ -74,9 +74,33 @@ const classicblue20 = {
   buttonColors:buttonColors
 }
 
+const fewerHues = {
+  colors: {
+    primary: '#0F4C81',
+    secondary: '#26AD5E',
+    tertiary: '#0F4C81',
+    light: '#FFFFFF',
+    dark: '#082742'
+  },
+  pixelWeight:pixelWeight,
+  buttonColors:buttonColors
+}
+
+const grayScale = {
+  colors: {
+    primary: '#747578',
+    secondary: '#26AD5E',
+    tertiary: '#a3a4a6',
+    light: '#FFFFFF',
+    dark: '#353637'
+  },
+  pixelWeight:pixelWeight,
+  buttonColors:buttonColors
+}
+
 export default function Theme({ children }){
   return(
-    <ThemeProvider theme={classicblue20}>
+    <ThemeProvider theme={grayScale}>
       <GlobalFonts />{children}
     </ThemeProvider>
   )

--- a/src/components/views/layouts/stylingDevLayouts/DevChartLayout.js
+++ b/src/components/views/layouts/stylingDevLayouts/DevChartLayout.js
@@ -1,0 +1,131 @@
+import React, { useEffect } from 'react'
+import { Row } from 'shards-react'
+import useResponsiveStyles from '../../../../hooks/useResponsiveStyles'
+import NavButtons from '../../buttons/RoundEndNav'
+import Chart from '../../charts/ProgressChart'
+import styled from 'styled-components'
+import {Bug} from '../../buttons/Bug'
+import {SmallPixelBorderDouble, SmallPixelBorderOutline, MegaPixelBorder} from '../PixelBorder'
+import {Universe, Grid, Appetizer, Entree, Dessert} from '../Grids'
+import Theme from '../../Theme'
+import Legend from '../../charts/Legend'
+
+const StyledRow = styled(Row)`
+  display: flex;
+  justify-content: center;
+  text-align: center;
+  margin-left: 5%;
+  margin-right: 5%;
+  margin-top: ${props => props.margintop || 0};
+  margin-bottom: ${props => props.marginbottom || 0};
+`
+const ChartWrapper = styled.div`
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: center
+`
+const StatsH1 = styled.h1`
+color: ${props => props.theme.colors.dark};
+`
+
+const StatsH3 = styled.h3`
+color: ${props => props.theme.colors.tertiary};
+`
+const StatsH4 = styled.h4`
+color: ${props => props.theme.colors.light};
+.category {
+  color: ${props => props.theme.colors.tertiary};
+  font-weight: 600;
+  text-transform: uppercase;
+}
+.num {
+  color: ${props => props.theme.colors.secondary};
+}
+`
+// QUESTION: should we not display graphs on moblile? too small to read? or how to scale?
+function DevChartLayout({ chartData, round, finished, viewStats, nextRound }) {
+  const timesSummary = chartData.progressSummary.times
+  const attemptsSummary = chartData.progressSummary.attempts
+  const verbT = timesSummary.verb
+  const verbA = attemptsSummary.verb
+  const sizedStyles = useResponsiveStyles()
+  const { h1, h3, h4, layoutInfo } = sizedStyles
+  const vTColor = verbT === 'decreased' ? {color: '#26AD5E', fontWeight: '600'} : null
+  const vAColor = verbA === 'decreased' ? {color: '#26AD5E', fontWeight: '600'} : null
+  useEffect(() => {
+      window.scrollTo(0, 0)
+  },[])
+
+  return (
+    <Theme>
+      <Universe>
+        <Grid style={layoutInfo}>
+          <Appetizer>
+            <MegaPixelBorder>
+              <StatsH1 style={h1}>Round {round} Complete!</StatsH1>
+            </MegaPixelBorder>
+          </Appetizer>
+          <Entree>
+              <SmallPixelBorderDouble>
+                  <StatsH3 style={h3}>Here's what changed the most this round!</StatsH3>
+                <ChartWrapper>
+                  <Chart showLegend={false} chartData={chartData} qTypes={chartData.chartData.categoriesAtt} metric={'attempts'} />
+                  <Chart showLegend={false} chartData={chartData} qTypes={chartData.chartData.categoriesTime} metric={'times'} />
+                </ChartWrapper>
+                <Legend chartData={chartData} />
+              </ SmallPixelBorderDouble>
+          </Entree>
+          <Dessert>
+            <SmallPixelBorderOutline>
+              <StatsH3 style={h3}>Here's Your Progress:</StatsH3>
+              <StyledRow>
+                <StatsH4 style={h4}>
+                  <span class='category'>
+                    attempts:
+                  </span><br />
+                   Your total attempt count{'\u00A0'}
+                  <span style={vAColor}>
+                    {verbA}{'\u00A0'}
+                  </span>
+                   by{'\u00A0'}
+                  <span class='num'>
+                    {attemptsSummary.num}{'\u00A0'}
+                  </span>
+                   attempts per question or{'\u00A0'}
+                  <span class='num'>
+                    {`${attemptsSummary.percent}%`}
+                  </span>
+                  .
+                </StatsH4>
+              </StyledRow>
+              <StyledRow>
+                <StatsH4 style={h4}>
+                  <span class='category'>
+                    time:
+                  </span><br />
+                  Your overall time{'\u00A0'}
+                  <span style={vTColor}>
+                    {verbT}{'\u00A0'}
+                  </span>
+                   by{'\u00A0'}
+                  <span class='num'>
+                    {timesSummary.num}{'\u00A0'}
+                  </span>
+                   seconds per question or{'\u00A0'}
+                  <span class='num'>
+                    {`${timesSummary.percent}%`}
+                  </span>
+                  .
+                </StatsH4>
+              </StyledRow>
+            </SmallPixelBorderOutline>
+            <NavButtons viewStats={viewStats} nextRound={nextRound} finished={finished}/>
+          </Dessert>
+        </Grid>
+        <Bug />
+      </Universe>
+    </Theme>
+  )
+}
+
+export default React.memo(DevChartLayout)

--- a/src/components/views/layouts/stylingDevLayouts/DevQuizQuestion.js
+++ b/src/components/views/layouts/stylingDevLayouts/DevQuizQuestion.js
@@ -1,0 +1,88 @@
+import React, { useEffect } from 'react'
+import Vexflow from '../../Vexflow'
+import AnswerChoice from '../../buttons/AnswerChoice'
+import useResponsiveStyles from '../../../../hooks/useResponsiveStyles'
+import styled from 'styled-components'
+import {MegaPixelBorder} from '../PixelBorder'
+import {Bug} from '../../buttons/Bug'
+import {Universe, Grid, Entree, Dessert} from '../Grids'
+import Theme from '../../Theme'
+
+
+const QuestionH5 = styled.h5`
+  color: ${props => props.theme.colors.light};
+  padding: 0 5% 5% 5%;
+`
+const ButtonBox = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-flow: row wrap;
+  > * {
+    margin: 2%;
+  }
+`
+
+const VexFlowCenteringDiv = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`
+
+export default function DevQuizQuestion(props) {
+  const sizedStyles = useResponsiveStyles()
+  const { h5, layoutQuiz } = sizedStyles
+  const { chord, question, colors, handleClick, onKeyPressed, currentInput } = props
+  const noteColors = question.type === 'Names' || question.type === 'Roots' ? colors.filter(input => input.color === 'green').map(input => input.input) : []
+
+  useEffect(() => {
+      window.scrollTo(0, 0)
+  },[question])
+
+  return (
+    <Theme>
+      <div style={{outline:'none'}}
+        onKeyDown={(e) => onKeyPressed(e)}
+        tabIndex="1"
+        ref={keyboard => keyboard && keyboard.focus()}
+        >
+        <Universe>
+          <Grid style={layoutQuiz}>
+            <Entree>
+              <QuestionH5 style={h5}>{question.questionText}</QuestionH5>
+              <MegaPixelBorder>
+                <VexFlowCenteringDiv>
+                  <Vexflow
+                    notes={chord.current.notes}
+                    octaves={chord.current.octaves}
+                    clef={chord.current.clef}
+                    keySig={chord.current.keySignature}
+                    colors={noteColors}
+                    />
+                </VexFlowCenteringDiv>
+              </MegaPixelBorder>
+            </Entree>
+            <Dessert>
+              <ButtonBox>
+                {question.choices.map(choice => {
+                  return (
+                    <AnswerChoice
+                      onClick={(e) => handleClick(choice.choice)}
+                      choice={choice.choice}
+                      key={choice.key}
+                      keystroke={choice.key}
+                      input={currentInput}
+                      colors={colors}
+                      />
+                  )}
+                )}
+              </ButtonBox>
+            </Dessert>
+          </Grid>
+          <Bug />
+        </Universe>
+      </div>
+    </Theme>
+
+  )
+}

--- a/src/components/views/layouts/stylingDevLayouts/DevResultsTable.js
+++ b/src/components/views/layouts/stylingDevLayouts/DevResultsTable.js
@@ -6,119 +6,6 @@ import { questionsList } from '../../../../generator/questionsList'
 import {Bug} from '../../buttons/Bug'
 import Theme from '../../Theme'
 
-const testData = {
-          "LETTER_NAMES": {
-             "attempts": [
-                3,
-                1,
-                7
-             ],
-             "times": [
-                2.3,
-                1.85,
-                67.3
-             ]
-          },
-          "ROOT": {
-             "attempts": [
-                null,
-                null,
-                null,
-             ],
-             "times": [
-                null,
-                null,
-                null
-             ]
-          },
-          "DEGREE": {
-             "attempts": [
-                4,
-                9,
-                2
-             ],
-             "times": [
-                4.5,
-                6,
-                1.2
-             ]
-          },
-          "ROLE": {
-             "attempts": [
-                2,
-                6,
-                3
-             ],
-             "times": [
-                1.2,
-                1.2,
-                3.4
-             ]
-          },
-          "NUMERAL": {
-             "attempts": [
-                null,
-                null,
-                null
-             ],
-             "times": [
-                null,
-                null,
-                null
-             ]
-          },
-          "QUALITY": {
-             "attempts": [
-                null,
-                4,
-                1,
-                5
-             ],
-             "times": [
-                null,
-                0.5,
-                1.2,
-                1.9
-             ]
-          },
-          "INVERSION": {
-             "attempts": [
-                2,
-                null,
-                null
-             ],
-             "times": [
-                0.3,
-                null,
-                null
-             ]
-          },
-          "FOLLOWED_BY": {
-             "attempts": [
-                null,
-                null,
-                2
-             ],
-             "times": [
-                null,
-                null,
-                3.4
-             ]
-          },
-          "Overall": {
-             "attempts": [
-                3,
-                2,
-                5
-             ],
-             "times": [
-                1.18,
-                2.3,
-                6.4
-             ]
-          }
-    }
-
 
 function replaceNaNs(num) {
   if (isNaN(num) || num === 0) {
@@ -129,8 +16,8 @@ function replaceNaNs(num) {
 
 // QUESTION: when implementing reducers dispatch an update to session data that includes best/worst info?
 export default function DevResultsTable(props) {
-  const { round, startOver } = props
-  const means = testData
+  const { round, startOver, mockData } = props
+  const means = mockData
   const qTypes = Object.keys(questionsList)
   const perfectRounds = (means.Overall.attempts.filter(average => average === 1)).length
   const greeting = perfectRounds >= 1 ? `Pefection! You completed ${perfectRounds} rounds with 100% accuracy this session.` : `No perfect rounds this session, but you'll get there next time!`

--- a/src/components/views/layouts/stylingDevLayouts/DevResultsTable.js
+++ b/src/components/views/layouts/stylingDevLayouts/DevResultsTable.js
@@ -1,10 +1,10 @@
 import React, { useEffect } from 'react'
-import { rounded } from '../../../utility'
+import { rounded } from '../../../../utility'
 // import HorizontalTable from '../charts/HorizontalTable'
-import VerticalTable from '../charts/VerticalTable'
-import { questionsList } from '../../../generator/questionsList'
-import {Bug} from '../buttons/Bug'
-import Theme from '../Theme'
+import VerticalTable from '../../charts/VerticalTable'
+import { questionsList } from '../../../../generator/questionsList'
+import {Bug} from '../../buttons/Bug'
+import Theme from '../../Theme'
 
 const testData = {
           "LETTER_NAMES": {

--- a/src/components/views/layouts/stylingDevLayouts/DevStartScreen.js
+++ b/src/components/views/layouts/stylingDevLayouts/DevStartScreen.js
@@ -1,0 +1,60 @@
+import React, { useEffect } from 'react'
+import SessionOptions from '../../buttons/SessionOptions'
+import Go from '../../buttons/Go'
+import useResponsiveStyles from '../../../../hooks/useResponsiveStyles'
+import {SmallPixelBorderSingle, MegaPixelBorder} from '../PixelBorder'
+import Marquee from '../Marquee'
+import Expander from '../Expander'
+import Instructions from '../Instructions'
+import {BugWithSpeechBubble} from '../../buttons/Bug'
+import {Universe, Grid, Appetizer, Entree, Dessert, SubCellMargin} from '../Grids'
+import Theme from '../../Theme'
+import {whatDoINeedToKnow} from '../../../../whatDoINeedToKnow'
+
+
+export default function DevStartScreen({ title, generateQuiz, numQs, onCheck, options }) {
+  const sizedStyles = useResponsiveStyles()
+  const { input, layoutInfo } = sizedStyles
+  const onKeyPressed = (e) => {
+    if (e.key === 'Enter') {
+      generateQuiz()
+    }
+  }
+
+  useEffect(() => {
+    window.scrollTo(0, 0)
+  }, [])
+
+  return (
+    <Theme>
+      <div style={{outline:'none'}}
+        onKeyDown={(e) => onKeyPressed(e)}
+        tabIndex="1"
+        ref={keyboard => keyboard && keyboard.focus()}
+        >
+        <Universe>
+          <Grid style={layoutInfo}>
+            <Appetizer>
+              <MegaPixelBorder>
+                <Marquee title={title}/>
+              </MegaPixelBorder>
+              <SubCellMargin>
+                <SessionOptions checked={options} onChange={(e) => { numQs.current = e.target.value }} onCheck={onCheck} size={input} />
+                <Go onClick={generateQuiz} />
+              </SubCellMargin>
+            </Appetizer>
+            <Entree>
+              <SmallPixelBorderSingle>
+                  <Instructions infoText="In a round of Chord Crusher, you/’ll answer a series of questions about each chord. You can choose the number of chords in a round (if you/’re a newbie, try 5 chords). The goal is to answer questions in a round as quickly as possible, and then to beat your time in each successive round. Will you crush the chords? Or will the chords crush YOU?!"/>
+              </SmallPixelBorderSingle>
+              <Expander infoText={whatDoINeedToKnow}/>
+            </Entree>
+            <Dessert>
+            </Dessert>
+          </Grid>
+          <BugWithSpeechBubble />
+        </Universe>
+      </div>
+    </Theme>
+  )
+}

--- a/src/components/views/layouts/stylingDevLayouts/DevStatLines.js
+++ b/src/components/views/layouts/stylingDevLayouts/DevStatLines.js
@@ -1,0 +1,86 @@
+import React, { useContext, useEffect } from 'react'
+import { Session } from '../../../data/Context'
+import {
+  Container,
+  Row,
+  Col
+} from 'shards-react'
+import useResponsiveStyles from '../../../../hooks/useResponsiveStyles'
+import styled from 'styled-components'
+import NavButtons from '../../buttons/RoundEndNav'
+import {SmallPixelBorderSingle, SmallPixelBorderDouble, SmallPixelBorderOutline, MediumPixelBorder, LargePixelBorder, JumboPixelBorder, MegaPixelBorder} from '../PixelBorder'
+import {Universe, Grid, Appetizer, Entree, Dessert, BugWrapper} from '../Grids'
+import {Bug} from '../../buttons/Bug'
+import Theme from '../../Theme'
+
+const StatsH1 = styled.h1`
+  color: ${props => props.theme.colors.dark};
+`
+
+const StatsH3 = styled.h3`
+  color: ${props => props.theme.colors.tertiary};
+  line-height: 0.75em!important;
+
+`
+const StatsH4 = styled.h4`
+  color: ${props => props.theme.colors.light};
+  .category {
+    color: ${props => props.theme.colors.tertiary};
+    font-weight: 600;
+    text-transform: uppercase;
+  }
+  .num {
+    color: ${props => props.theme.colors.secondary};
+  }
+`
+
+export default function DevStatLines(props) {
+  const { round, setShowStats, nextRound, finished } = props
+  const means = useContext(Session).means.tally
+  const qTypes = useContext(Session).means.questionsCurrentRound
+  const sizedStyles = useResponsiveStyles()
+  const { h1, h2, h3, h4, para, input, layoutInfo, layoutQuiz} = sizedStyles
+
+  useEffect(() => {
+      window.scrollTo(0, 0)
+  },[])
+
+  const headline = round === 1 ? 'First Round Complete!' : `Round ${round} Stats`
+  const subtitle = round === 1 ? `Here's Your Benchmark:` : null
+  const closing = round === 1 ? 'Try to beat these numbers in the next round!' : null
+  const statLines = qTypes.map( type => {
+    console.log("type:" + JSON.stringify(type))
+    return <Row
+            key={type}
+            style={{display: 'flex', justifyContent: 'center', textAlign: 'center'}}>
+              <p>
+                <span class='category'>{type.toUpperCase()}: </span><br />
+                <span class='num'>{means[type].attempts[means[type].attempts.length-1]}</span> attempts and <span class='num'>{means[type].times[means[type].times.length-1]}</span> seconds per question
+              </p>
+            </Row>
+  })
+
+  return (
+    <Theme>
+      <Universe>
+        <Grid style={layoutInfo}>
+          <Appetizer>
+            <MegaPixelBorder>
+              <StatsH1 style={h1}>{headline}</StatsH1>
+            </MegaPixelBorder>
+            <NavButtons viewStats={setShowStats} nextRound={nextRound} finished={finished} round={round} statLines/>
+          </Appetizer>
+          <Entree>
+            <SmallPixelBorderOutline>
+              <StatsH3 style={h3}>{subtitle}</StatsH3>
+              <StatsH4 style={h4}>{statLines}</StatsH4>
+              <StatsH3 style={h3}>{closing}</StatsH3>
+            </SmallPixelBorderOutline>
+          </Entree>
+        </Grid>
+        <Bug />
+      </Universe>
+    </Theme>
+
+  )
+}

--- a/src/components/views/layouts/stylingDevLayouts/DevStatLines.js
+++ b/src/components/views/layouts/stylingDevLayouts/DevStatLines.js
@@ -35,9 +35,15 @@ const StatsH4 = styled.h4`
 `
 
 export default function DevStatLines(props) {
-  const { round, setShowStats, nextRound, finished } = props
-  const means = useContext(Session).means.tally
-  const qTypes = useContext(Session).means.questionsCurrentRound
+  const { round, setShowStats, nextRound, finished, mockData } = props
+  const means = mockData
+  const qTypes = [
+     "Role",
+     "Names",
+     "Quality",
+     "Degrees",
+     "Overall"
+  ]
   const sizedStyles = useResponsiveStyles()
   const { h1, h2, h3, h4, para, input, layoutInfo, layoutQuiz} = sizedStyles
 

--- a/src/hooks/responsiveStyles.js
+++ b/src/hooks/responsiveStyles.js
@@ -4,7 +4,7 @@ const fontBody = "'Thintel', monospace"
 const makeBreakpoints = function ({fontFamily, textAlign, baseSize, letterSpacing, lineHeight, textTransform, multiplier}) {
   const largeFactor = 1.15
   const mediumFactor = 1.1
-  const multiply = multiplier ? 2 : 1
+  const multiply = multiplier ? 1.25 : 1
   let result = {LARGE:{}, MEDIUM:{}, SMALL:{}}
   result.LARGE = {
     fontFamily:fontFamily,


### PR DESCRIPTION
@jsbean want to merge this in before we do our next heroku push? It includes the grayscale and green theme and the new routes for jumping straight to a mock of each view for styling. If you don't want to merge those dev routes into master (maybe it's a bad idea to have those be live?) I can just commit the theme changes directly to `master`.