### PR TITLE
Place viio7 on the correct rootOffset for minor keys

### DIFF
--- a/src/components/views/Theme.js
+++ b/src/components/views/Theme.js
@@ -76,9 +76,9 @@ const classicblue20 = {
 
 const fewerHues = {
   colors: {
-    primary: '#0F4C81',
+    primary: '#0F4C81', // outline light-ish blue
     secondary: '#26AD5E',
-    tertiary: '#0F4C81',
+    tertiary: '#5088B8', // lighter blue text
     light: '#FFFFFF',
     dark: '#082742'
   },
@@ -100,7 +100,7 @@ const grayScale = {
 
 export default function Theme({ children }){
   return(
-    <ThemeProvider theme={grayScale}>
+    <ThemeProvider theme={fewerHues}>
       <GlobalFonts />{children}
     </ThemeProvider>
   )

--- a/src/generator/ChordStructure.js
+++ b/src/generator/ChordStructure.js
@@ -128,7 +128,7 @@ export const ChordStructure = {
     ],
     possibleRootOffsets: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
     commonRootOffsets: {
-      minor: [10] // viio7
+      minor: [11] // viio7
     }
   },
   NEAPOLITAN_SIXTH: { // This is treated as a Major triad. It will most often show up in first inversion, but can also show up in root position. See commit notes about decoupling commonRootOffsets.


### PR DESCRIPTION
This PR places viio7 at the correct root offset. It is currently on `10`, but it should be _raised_ to `11`.

@davidforrest, do you want to give this a couple tried to verify the spelling is ok?

Then, if @davidforrest signs off on this, @1aurend: would you want to push this up to Heroku sooner rather than later?